### PR TITLE
Remove use of the injector, making configuration more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ class App {
 
 bootstrap(App, [
   HTTP_PROVIDERS,
-  provide(AuthHttp, { useFactory: () => {
-    return new AuthHttp()
-  }})
+  provide(AuthConfig, {
+      useFactory: () => {
+          return new AuthConfig();
+      }
+  }),
+  AuthHttp
 ])
 ```
 
@@ -72,8 +75,8 @@ By default, if there is no valid JWT saved, `AuthHttp` will throw an 'Invalid JW
 
 bootstrap(App, [
   HTTP_PROVIDERS,
-  provide(AuthHttp, { useFactory: () => {
-    return new AuthHttp({
+  provide(AuthConfig, { useFactory: () => {
+    return new AuthConfig({
       headerName: YOUR_HEADER_NAME,
       headerPrefix: YOUR_HEADER_PREFIX,
       tokenName: YOUR_TOKEN_NAME,

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -56,13 +56,10 @@ export class AuthHttp {
 
   private _config: IAuthConfig;
   public tokenStream: Observable<string>;
-  http: Http;
 
-  constructor(config?:Object) {
-    this._config = new AuthConfig(config).getConfig();
-    var injector = Injector.resolveAndCreate([HTTP_PROVIDERS]);
-    this.http = injector.get(Http);
-    
+  constructor(options:AuthConfig,private http:Http) {
+    this._config = options.getConfig();
+
     this.tokenStream = new Observable((obs:any) => {
       obs.next(this._config.tokenGetter())
     });


### PR DESCRIPTION
I made this more explicit as implicit configuration is brittle and more problematic. By doing it this way, testing is easier, and potentially AuthHttp is now composable with other Http Wrappers.