### PR TITLE
Support token refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ For examples on integrating **angular2-jwt** with Webpack and SystemJS, see [aut
 * Send a JWT on a per-request basis using the **explicit `AuthHttp`** class
 * **Decode a JWT** from your Angular 2 app
 * Check the **expiration date** of the JWT
+* Call **Token Refresh** function if the JWT has expired
 * Conditionally allow **route navigation** based on JWT status
 
 ## Installation
@@ -32,7 +33,7 @@ import {AuthHttp, AuthConfig} from 'angular2-jwt';
 ...
 
 class App {
-  
+
   thing: string;
 
   constructor(public authHttp: AuthHttp) {}
@@ -64,9 +65,11 @@ A default configuration for header and token details is provided:
 * Header Prefix: `Bearer`
 * Token Name: `id_token`
 * Token Getter Function: `(() => localStorage.getItem(tokenName))`
+* Token Refresh Function `(() => Observable.of(null))`
+* Token Refresh Offset: 60
 * Supress error and continue with regular HTTP request if no JWT is saved: `false`
 
-If you wish to configure the `headerName`, `headerPrefix`, `tokenName`, `tokenGetter` function, or `noJwtError` boolean, you can pass a config object when `AuthHttp` is injected.
+If you wish to configure the `headerName`, `headerPrefix`, `tokenName`, `tokenGetter` function, `refresh` function, `refreshOffset`, or `noJwtError` boolean, you can pass a config object when `AuthHttp` is injected.
 
 By default, if there is no valid JWT saved, `AuthHttp` will throw an 'Invalid JWT' error. If you would like to continue with an unauthenticated request instead, you can set `noJwtError` to `true`.
 
@@ -81,7 +84,9 @@ bootstrap(App, [
       headerPrefix: YOUR_HEADER_PREFIX,
       tokenName: YOUR_TOKEN_NAME,
       tokenGetter: YOUR_TOKEN_GETTER_FUNCTION,
-      noJwtError: true 
+      refresh: YOUR_TOKEN_REFRESH_FUNCTION,
+      refreshOffset: YOUR_TOKEN_REFRESH_OFFSET,
+      noJwtError: true
     })
   }}),
   AuthHttp
@@ -98,14 +103,14 @@ You may send custom headers with your `authHttp` request by passing in an option
 getThing() {
   var myHeader = new Headers();
   myHeader.append('Content-Type', 'application/json');
-  
+
   this.authHttp.get('http://example.com/api/thing', { headers: myHeader} )
     .subscribe(
       data => this.thing = data,
       err => console.log(error),
       () => console.log('Request Complete')
     );
-    
+
   // Pass it after the body in a POST request
   this.authHttp.post('http://example.com/api/thing', 'post body', { headers: myHeader} )
     .subscribe(
@@ -114,7 +119,7 @@ getThing() {
       () => console.log('Request Complete')
     );
 }
-``` 
+```
 
 ### Using the Observable Token Stream
 
@@ -154,7 +159,7 @@ jwtHelper: JwtHelper = new JwtHelper();
 
 useJwtHelper() {
   var token = localStorage.getItem('id_token');
-  
+
   console.log(
     this.jwtHelper.decodeToken(token),
     this.jwtHelper.getTokenExpirationDate(token),
@@ -167,7 +172,7 @@ useJwtHelper() {
 
 ## Checking Login to Hide/Show Elements and Handle Routing
 
-The `tokenNotExpired` function can be used to check whether a JWT exists in local storage, and if it does, whether it has expired or not. If the token is valid, `tokenNotExpired` returns `true`, otherwise it returns `false`. 
+The `tokenNotExpired` function can be used to check whether a JWT exists in local storage, and if it does, whether it has expired or not. If the token is valid, `tokenNotExpired` returns `true`, otherwise it returns `false`.
 
 The router's `@CanActivate` lifecycle hook can be used with `tokenNotExpired` to determine if a route should be accessible. This lifecycle hook is run before the component class instantiates. If `@CanActivate` receives `true`, the router will allow navigation, and if it receives `false`, it won't.
 

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -33,7 +33,7 @@ export class AuthConfig {
   constructor(config?: any) {
     this.config = config || {};
     this.headerName = this.config.headerName || 'Authorization';
-    this.headerPrefix = this.config.headerPrefix || 'Bearer';
+    this.headerPrefix = this.config.headerPrefix + ' ' || 'Bearer ';
     this.tokenName = this.config.tokenName || 'id_token';
     this.tokenGetter = this.config.tokenGetter || (() => localStorage.getItem(this.tokenName));
     this.refresh = this.config.refresh || (() => Observable.of(null));
@@ -83,7 +83,7 @@ export class AuthHttp {
 
     var token = this._config.tokenGetter()
     if (token && this.jwtHelper.isTokenExpired(token, this._config.refreshOffset)) {
-        refreshToken = this._config.refresh();
+      refreshToken = this._config.refresh();
     } else {
       refreshToken = Observable.of(token);
     }

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -10,6 +10,8 @@ export interface IAuthConfig {
   headerPrefix: string;
   tokenName: string;
   tokenGetter: any;
+  refresh: any;
+  refreshOffset: number;
   noJwtError: boolean;
 }
 
@@ -18,21 +20,25 @@ export interface IAuthConfig {
  */
 
 export class AuthConfig {
-  
+
   config: any;
   headerName: string;
   headerPrefix: string;
   tokenName: string;
   tokenGetter: any;
+  refresh: any;
+  refreshOffset: number;
   noJwtError: boolean;
 
   constructor(config?: any) {
     this.config = config || {};
     this.headerName = this.config.headerName || 'Authorization';
-    this.headerPrefix = this.config.headerPrefix + ' ' || 'Bearer ';
+    this.headerPrefix = this.config.headerPrefix || 'Bearer';
     this.tokenName = this.config.tokenName || 'id_token';
-    this.noJwtError = this.config.noJwtError || false;
     this.tokenGetter = this.config.tokenGetter || (() => localStorage.getItem(this.tokenName));
+    this.refresh = this.config.refresh || (() => Observable.of(null));
+    this.refreshOffset = this.config.refreshOffset || 60;
+    this.noJwtError = this.config.noJwtError || false;
   }
 
   getConfig() {
@@ -41,6 +47,8 @@ export class AuthConfig {
       headerPrefix: this.headerPrefix,
       tokenName: this.tokenName,
       tokenGetter: this.tokenGetter,
+      refresh: this.refresh,
+      refreshOffset: this.refreshOffset,
       noJwtError: this.noJwtError
     }
   }
@@ -56,57 +64,74 @@ export class AuthHttp {
 
   private _config: IAuthConfig;
   public tokenStream: Observable<string>;
+  private jwtHelper:JwtHelper;
 
   constructor(options: AuthConfig, private http: Http) {
     this._config = options.getConfig();
+    this.jwtHelper = new JwtHelper();
 
     this.tokenStream = new Observable((obs: any) => {
       obs.next(this._config.tokenGetter())
     });
   }
 
-  _request(url: string | Request, options?: RequestOptionsArgs) : Observable<Response> {
+  _request(req: Request) : Observable<Response> {
 
     let request:any;
-    
-    if(!tokenNotExpired(null, this._config.tokenGetter())) {
-      if(!this._config.noJwtError) {
-        throw 'Invalid JWT';
+
+    // this is observable as it may need to come from an http call ...
+    let refreshToken:Observable<string>;
+
+    var token = this._config.tokenGetter()
+    // do we even have a token?
+    if (token === null) {
+      // no, is this an error?
+      if(this._config.noJwtError) {
+        // no, we can provide this token to the request
+        refreshToken = Observable.of(token)
       } else {
-        request = this.http.request(url, options);
+        // yes, we can't do anything
+        throw 'Invalid JWT';
       }
-      
-    } else if(typeof url === 'string') {
-      let reqOpts = options || {};
-      
-      if(!reqOpts.headers) {
-        reqOpts.headers = new Headers();
+    } else{
+      // yes, we have a token ... is it still valid? (with some allowance)
+      if (this.jwtHelper.isTokenExpired(token, this._config.refreshOffset)) {
+        // no, it's expired - we'll call the token refresh prior to the call
+        refreshToken = this._config.refresh();
+      } else {
+        // yes, it's still good so we can provide this token to the request
+        refreshToken = Observable.of(token);
       }
-      
-      reqOpts.headers.set(this._config.headerName, this._config.headerPrefix + this._config.tokenGetter());
-      request = this.http.request(url, reqOpts);
-      
-    } else {
-      let req:Request = <Request>url;
-      
-      if(!req.headers) {
-        req.headers = new Headers();
-      }
-      
-      req.headers.set(this._config.headerName, this._config.headerPrefix + this._config.tokenGetter());
-      request = this.http.request(req);
     }
-    
+
+    if(!req.headers) {
+      req.headers = new Headers();
+    }
+
+    // chain it after the refresh call
+    request = refreshToken.flatMap(token => {
+      if (token === null) {
+        if (!this._config.noJwtError) {
+          return Observable.throw('Invalid JWT');
+        }
+      } else {
+        // we add the auth headers here because it may be the new one returned from the refresh method
+        req.headers.set(this._config.headerName, this._config.headerPrefix + token);
+      }
+      // and now return the actual call for subscribers to use
+      return this.http.request(req);
+    });
+
     return request;
   }
 
   private requestHelper(requestArgs: RequestOptionsArgs, additionalOptions: RequestOptionsArgs) : Observable<Response> {
     let options = new RequestOptions(requestArgs);
-    
+
     if(additionalOptions) {
       options = options.merge(additionalOptions)
     }
-    
+
     return this._request(new Request(options))
   }
 
@@ -215,7 +240,7 @@ export function tokenNotExpired(tokenName?:string, jwt?:string) {
   }
 
   var jwtHelper = new JwtHelper();
-  
+
   if(!token || jwtHelper.isTokenExpired(token, null)) {
     return false;
   }


### PR DESCRIPTION
If the existing access token has expired or is within a `refreshOffset` (seconds) of expiring then a `refresh` function can be called to obtain a new access token prior to the http request. This happens transparently to the caller / user of `AuthHttp`.

The `refresh` function should return an Observable<string> of the new access token (after storing it).

An example refresh function:

```
refresh_token():Observable<string> {
    var refresh_token = localStorage.getItem('refresh_token');
    var data = {
      client_id: this.config.client_id,
      client_secret: this.config.client_secret,
      grant_type: 'refresh_token',
      refresh_token: refresh_token
    };
    var body = this.serializeForm(data);
    var headers = new Headers();
    headers.append('Content-Type', 'application/x-www-form-urlencoded');
    return this.http.post(tokenEndpoint, body, {
        headers: headers
      })
      .map(res => {
          var data = res.json();
          localStorage.setItem("access_token", data.access_token);
          localStorage.setItem("refresh_token", data.refresh_token);
          return data.access_token;
        }
      );
  }
```

Example config:

```
provide(AuthConfig, { useFactory: (auth) => {
      return new AuthConfig({
          headerName: "Authorization",
          headerPrefix: "Bearer ",
          tokenName: "access_token",
          tokenGetter: (() => localStorage.getItem("access_token")),
          refresh: (() => auth.refresh_token()),
          refreshOffset: 300,
          noJwtError: true,
      })
  }, deps:[AuthService]})
```