### PR TITLE
chore(package.json) allow all beta versions of ng2/rx

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "typings": "./angular2-jwt.d.ts",
   "homepage": "https://github.com/auth0/angular2-jwt#readme",
   "dependencies": {
-    "angular2": "^2.0.0-beta.0",
+    "angular2": ">=2.0.0-beta.0",
     "zone.js": "^0.5.10",
-    "rxjs": "^5.0.0-beta.0"
+    "rxjs": ">=5.0.0-beta.0"
   },
   "devDependencies": {
     "systemjs": "~0.19.6",


### PR DESCRIPTION
As per: https://docs.npmjs.com/misc/semver#prerelease-tags

Should fix #22