### PR TITLE
Bump to latest angular2 and zone versions.

### DIFF
--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -1,3 +1,4 @@
+///<reference path="node_modules/angular2/typings/browser.d.ts"/>
 import {Injectable, Injector} from 'angular2/core';
 import {Http, HTTP_PROVIDERS, Headers, BaseRequestOptions, Request, RequestOptions, RequestOptionsArgs, RequestMethod, Response} from 'angular2/http';
 import {Observable} from 'rxjs/Observable';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-jwt",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Helper library for handling JWTs in Angular 2",
   "repository": {
     "type": "git",
@@ -25,8 +25,8 @@
   "typings": "./angular2-jwt.d.ts",
   "homepage": "https://github.com/auth0/angular2-jwt#readme",
   "dependencies": {
-    "angular2": ">=2.0.0-beta.0",
-    "zone.js": "^0.5.10",
+    "angular2": ">=2.0.0-beta.6",
+    "zone.js": "0.5.14",
     "rxjs": "5.0.0-beta.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bump angular2 to beta 6
Bump zone to 5.14
Bump project version to 1.7

Add header to the angular2-jwt module as described in the [changelog](https://github.com/angular/angular/blob/master/CHANGELOG.md) because this project targets ES5

Have you got any tests anywhere?
I've run it in my local app using `npm link` but I have a limited use case

If your not happy to merge this a change should be made to the dependency specifications for angular2 & zone. versions > beta.0 require zone 5.11 but its pinned to 5.10.