### PR TITLE
move typings dependency to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
   "dependencies": {
     "angular2": ">=2.0.0-beta.7",
     "zone.js": "^0.5.15",
-    "rxjs": "5.0.0-beta.2"
+    "rxjs": "5.0.0-beta.2",
+    "typings": "^0.6.8"
   },
   "devDependencies": {
     "systemjs": "~0.19.6",
-    "typescript": "~1.7.5",
-    "typings": "^0.6.8"
+    "typescript": "~1.7.5"
   }
 }


### PR DESCRIPTION
with the typings dependency in devDependencies, it will fail to install
when users use `npm install angular2-jwt`  since the postinstall script
uses typings.