### PR TITLE
Removed duplicated Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ bootstrap(App, [
       }), http);
     },
     deps: [Http]
-  }),
-  AuthHttp
+  })
 ])
 ```
 


### PR DESCRIPTION
Removed duplicated provider for AuthHttp. If have both providers, the second one seems to override the first one, so the factory is missing and a  provider for AuthConfig cannot be found.