### PR TITLE
remove AuthHttp from app bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ bootstrap(App, [
       return new AuthHttp(new AuthConfig(), http);
     },
     deps: [Http]
-  }),
-  AuthHttp
+  })
 ])
 ```
 


### PR DESCRIPTION
the second AuthHttp cause the framework to ignore the one that was injected before causing `No provider for AuthConfig!`