### PR TITLE
Expose request & cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ Thumbs.db
 *.js
 *.map
 *.d.ts
+.idea/
+*.iml

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -1,5 +1,5 @@
-import {Injectable, Injector} from 'angular2/core';
-import {Http, HTTP_PROVIDERS, Headers, BaseRequestOptions, Request, RequestOptions, RequestOptionsArgs, RequestMethod, Response} from 'angular2/http';
+import {Injectable} from 'angular2/core';
+import {Http, Headers, Request, RequestOptions, RequestOptionsArgs, RequestMethod, Response} from 'angular2/http';
 import {Observable} from 'rxjs/Observable';
 
 // Avoid TS error "cannot find name escape"

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -69,7 +69,7 @@ export class AuthHttp {
     });
   }
 
-  _request(url: string | Request, options?: RequestOptionsArgs) : Observable<Response> {
+  request(url: string | Request, options?: RequestOptionsArgs) : Observable<Response> {
 
     let request:any;
     
@@ -111,7 +111,7 @@ export class AuthHttp {
       options = options.merge(additionalOptions)
     }
     
-    return this._request(new Request(options))
+    return this.request(new Request(options))
   }
 
   get(url: string, options?: RequestOptionsArgs) : Observable<Response> {

--- a/package.json
+++ b/package.json
@@ -27,12 +27,13 @@
   "homepage": "https://github.com/auth0/angular2-jwt#readme",
   "dependencies": {
     "angular2": ">=2.0.0-beta.12",
-    "zone.js": "^0.6.6",
+    "es6-shim": "^0.35.0",
+    "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.2",
-    "typings": "^0.7.9"
+    "zone.js": "^0.6.6"
   },
   "devDependencies": {
-    "systemjs": "~0.19.6",
-    "typescript": "^1.8.9"
+    "typescript": "^1.8.9",
+    "typings": "^0.7.12"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,14 +8,8 @@
         "sourceMap": true,
         "declaration": true
     },
-    "exclude": [
-        "node_modules",
-        "typings/main.d.ts",
-        "typings/main"
-    ],
-    "filesGlob": [
-        "*.ts",
-        "!./node_modules/**/*.ts",
+    "files": [
+        "angular2-jwt.ts",
         "typings/browser.d.ts"
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "sourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "moduleResolution":"node"
     },
     "files": [
         "angular2-jwt.ts",


### PR DESCRIPTION
- Ignore idea project files
- Remove unused imports
- Simplify tsconfig
- expose request. no use waiting any longer for the http refactor
- fix module resolution
- clean up deps

I don't like having peer deps that we're not using in the dependencies, but I'm sure some contributor somewhere will complain. Also, typings works fine as a dev dependency, and it should be in dev-dependencies because that's what it is.