### PR TITLE
refactor: use interface for auth config object

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@angular/platform-browser": "^2.0.0",
     "@types/jasmine": "^2.2.33",
     "@types/js-base64": "^2.1.3",
+    "@types/object-assign": "^4.0.28",
     "awesome-typescript-loader": "^2.2.4",
     "core-js": "^2.3.0",
     "es6-shim": "^0.35.0",
@@ -55,6 +56,7 @@
     "rxjs": "5.0.0-beta.12"
   },
   "dependencies": {
-    "js-base64": "^2.1.9"
+    "js-base64": "^2.1.9",
+    "object-assign": "^4.1.0"
   }
 }


### PR DESCRIPTION
This makes use of the IAuthConfig interface
for the config object that is passed into
the ctor of AuthConfig class and returned
by getConfig method. Furthermore it simplifies
assignment of config object.

Unfortunately, I was **unable to run the tests** with `npm test`, cause i got the follow error from karma (stackoverflow question concerning the same error): http://stackoverflow.com/questions/24220888/error-you-need-to-include-some-adapter-that-implements-karma-start-method#24221029

Based on answers from stackoverflow, it seems that there is a karma.conf.js file missing. I have not used karma before, so at the moment I can't help you with that.