### PR TITLE
Change body from string to any

### DIFF
--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -133,11 +133,11 @@ export class AuthHttp {
     return this.requestHelper({ url:  url, method: RequestMethod.Get }, options);
   }
 
-  post(url: string, body: string, options?: RequestOptionsArgs) : Observable<Response> {
+  post(url: string, body: any, options?: RequestOptionsArgs) : Observable<Response> {
     return this.requestHelper({ url:  url, body: body, method: RequestMethod.Post }, options);
   }
 
-  put(url: string, body: string, options ?: RequestOptionsArgs) : Observable<Response> {
+  put(url: string, body: any, options ?: RequestOptionsArgs) : Observable<Response> {
     return this.requestHelper({ url:  url, body: body, method: RequestMethod.Put }, options);
   }
 
@@ -145,7 +145,7 @@ export class AuthHttp {
     return this.requestHelper({ url:  url, method: RequestMethod.Delete }, options);
   }
 
-  patch(url: string, body:string, options?: RequestOptionsArgs) : Observable<Response> {
+  patch(url: string, body:any, options?: RequestOptionsArgs) : Observable<Response> {
     return this.requestHelper({ url:  url, body: body, method: RequestMethod.Patch }, options);
   }
 


### PR DESCRIPTION
I added this change because it can create issues with rest apis. Basically being forced to stringify the object body converts the data to text/plain and having to set up the backend to accept both text and json can quickly be tedious (and most rest apis will expect json as the body). 

If you disagree, just close off this PR - figured it was easier on you guys than making an issue first. :)