### PR TITLE
Workaround for RC5's bug with empty body in HTTP GET

### DIFF
--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -107,7 +107,10 @@ export class AuthHttp {
     } else {
       req.headers.set(this._config.headerName, this._config.headerPrefix + this._config.tokenGetter());
     }
-    return this.http.request(req);
+    // work around Angular2 RC5 bug https://github.com/angular/angular/issues/10612
+    if (req._body === undefined || req._body === null)
+      req._body = "";
+    return this.http.request(req, options);
   }
 
   private mergeOptions(defaultOpts: RequestOptions, providedOpts: RequestOptionsArgs) {


### PR DESCRIPTION
RC5's `Http` throws an error when the body of a request is set to `null`. For a GET request this is usually the case. Work around this issue by setting it to an empty string before passing the request on to `Http`. Also pass the `options` argument.