### PR TITLE
Handle Promised TokenGetter, Issue #126

### DIFF
--- a/angular2-jwt.spec.ts
+++ b/angular2-jwt.spec.ts
@@ -1,7 +1,8 @@
 import "core-js";
-import {AuthConfig} from "./angular2-jwt";
+import {AuthConfig, AuthHttp} from "./angular2-jwt";
 import {tokenNotExpired} from "./angular2-jwt";
 import {JwtHelper} from "./angular2-jwt";
+import {Observable} from "rxjs";
 
 
 const expiredToken="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjB9.m2OKoK5-Fnbbg4inMrsAQKsehq2wpQYim8695uLdogk";
@@ -140,4 +141,33 @@ describe('tokenNotExpired', ()=> {
         expect(actual).toBe(false);
     });
 
+});
+
+describe("AuthHttp", () => {
+    describe("request", () => {
+        it("handles tokenGetters returning string", () => {
+            let authHttp: AuthHttp = new AuthHttp(new AuthConfig({
+                tokenGetter: () => validToken
+            }), null);
+
+            spyOn(authHttp, "requestWithToken").and.stub();
+
+            authHttp.request(null);
+
+            expect(authHttp["requestWithToken"]).toHaveBeenCalledWith(null, validToken);
+        });
+
+        it("handles tokenGetters returning Promise\<string\>", (done: Function) => {
+            let authHttp: AuthHttp = new AuthHttp(new AuthConfig({
+                tokenGetter: () => Promise.resolve(validToken)
+            }), null);
+
+            spyOn(authHttp, "requestWithToken").and.returnValue(Observable.of(""));
+
+            authHttp.request(null).subscribe(() => {
+                expect(authHttp["requestWithToken"]).toHaveBeenCalledWith(null, validToken);
+                done();
+            });
+        });
+    });
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,70 @@
+module.exports = function (config) {
+    'use strict';
+
+    config.set({
+        basePath: './',
+        frameworks: ["jasmine"],
+        // list of files / patterns to load in the browser
+        files: [
+            {pattern: 'angular2-jwt.spec.ts', watched: false}
+        ],
+
+        // list of files / patterns to exclude
+        exclude: [],
+
+        preprocessors: {
+            'angular2-jwt.spec.ts': [ 'webpack', 'sourcemap']
+        },
+
+
+        webpackServer: {
+            noInfo: true
+            //progress:false,
+            //stats: false,
+            //debug:false
+        },
+
+        // web server port
+        port: 9876,
+
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
+
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
+
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: false,
+
+        browsers: [
+            //"Firefox",
+            //"Chrome",
+            //"IE",
+            "PhantomJS"
+        ],
+
+        // Continuous Integration mode
+        // if true, it capture browsers, run tests and exit
+        singleRun: true,
+
+        reporters: ['progress'],
+
+        webpack: {
+            resolve: {
+                extensions: ['', '.ts', '.js']
+            },
+            module: {
+                loaders: [
+                    {test: /\.ts$/,loader: 'awesome-typescript-loader'}
+                ]
+            },
+            stats: {
+                colors: true,
+                reasons: true
+            },
+            debug: false,
+            devtool: 'inline-source-map'
+        }
+    });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     },
     "files": [
         "angular2-jwt.ts",
+        "angular2-jwt.spec.ts",
         "typings/browser.d.ts",
         "custom.d.ts"
     ]


### PR DESCRIPTION
With this Pull-Request the Token-Getter can return a `string `or a `Promise<string>`.
Fixes #126 

I would have liked to add some tests, but there's no test-configuration for running the available tests :(
