### PR TITLE
fix(JwtHelper) btoa does not support utf8 and escape is deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Thumbs.db
 .DS_Store
 
 *.js
+!karma.conf.js
 *.map
 *.d.ts
 !custom.d.ts

--- a/angular2-jwt.spec.ts
+++ b/angular2-jwt.spec.ts
@@ -1,9 +1,7 @@
 import "core-js";
-import {AuthConfig, AuthHttp} from "./angular2-jwt";
-import {tokenNotExpired} from "./angular2-jwt";
-import {JwtHelper} from "./angular2-jwt";
+import {AuthConfig, AuthHttp, tokenNotExpired, JwtHelper} from "./angular2-jwt";
 import {Observable} from "rxjs";
-
+import {Base64} from "js-base64";
 
 const expiredToken="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjB9.m2OKoK5-Fnbbg4inMrsAQKsehq2wpQYim8695uLdogk";
 const validToken="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.K_lUwtGbvjCHP8Ff-gW9GykydkkXzHKRPbACxItvrFU";
@@ -53,8 +51,17 @@ describe('AuthConfig', ()=> {
 
 describe('JwtHelper', ()=> {
     'use strict';
+    let jwtHelper:JwtHelper;
+    beforeEach(()=>{
+        jwtHelper=new JwtHelper();
+    });
     describe('urlBase64Decode',()=>{
-        
+        it('should successfully decode payloads with funny symbols (A Euro symbol in this case) simplified',()=>{
+            const expected="€";
+            const payload=Base64.encode(expected);
+            const actual:any=jwtHelper.urlBase64Decode(payload);
+            expect(actual).toBe(expected);
+        });
     });
     describe('decodeToken',()=>{
 
@@ -63,10 +70,6 @@ describe('JwtHelper', ()=> {
 
     });
     describe('isTokenExpired',()=>{
-        let jwtHelper:JwtHelper;
-        beforeEach(()=>{
-            jwtHelper=new JwtHelper();
-        });
         it('should return false when the token is not expired', ()=> {
             const actual:boolean=jwtHelper.isTokenExpired(validToken);
             expect(actual).toBe(false);

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -1,3 +1,4 @@
+import { Base64 } from 'js-base64';
 import { Injectable, Provider } from '@angular/core';
 import { Http, Headers, Request, RequestOptions, RequestOptionsArgs, RequestMethod, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
@@ -187,8 +188,8 @@ export class JwtHelper {
         throw 'Illegal base64url string!';
       }
     }
-
-    return decodeURIComponent(encodeURI(typeof window === 'undefined' ? atob(output) : window.atob(output)));
+    // This does not use btoa because it does not support unicode and the various fixes were... wonky.
+    return Base64.decode(output);
   }
 
   public decodeToken(token: string): any {

--- a/package.json
+++ b/package.json
@@ -30,20 +30,21 @@
     "@angular/core": "^2.0.0",
     "@angular/http": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
-    "@types/es6-shim": "0.0.31",
+    "@types/es6-shim": "0.31.32",
     "@types/jasmine": "^2.2.33",
-    "awesome-typescript-loader": "^0.17.0",
+    "@types/js-base64": "^2.1.3",
+    "awesome-typescript-loader": "^2.2.4",
     "core-js": "^2.3.0",
     "es6-shim": "^0.35.0",
     "jasmine-core": "^2.4.1",
-    "karma": "^0.13.22",
-    "karma-chrome-launcher": "^0.2.3",
-    "karma-jasmine": "^0.3.8",
+    "karma": "^1.3.0",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-jasmine": "^1.0.2",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "^1.7.0",
     "phantomjs-prebuilt": "^2.1.7",
-    "reflect-metadata": "0.1.2",
+    "reflect-metadata": "0.1.8",
     "rxjs": "5.0.0-beta.12",
     "typescript": "^2.0.2",
     "webpack": "^1.13.0",
@@ -55,6 +56,6 @@
     "rxjs": "5.0.0-beta.12"
   },
   "dependencies": {
-    "atob": "^2.0.3"
+    "js-base64": "^2.1.9"
   }
 }


### PR DESCRIPTION
I'm not especially comfortable with adding a new library dependency, as this one is 3kb minified, but I felt it was necessary to solve this properly.

I updated the test dependencies as they were broken when typings was missing.

Closes #174