### PR TITLE
Use Travis for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# angular2-jwt [![npm version](https://img.shields.io/npm/v/angular2-jwt.svg)](https://www.npmjs.com/package/angular2-jwt) [![license](https://img.shields.io/npm/l/angular2-jwt.svg)](https://www.npmjs.com/package/angular2-jwt)
+# angular2-jwt
+[![Build Status](https://travis-ci.org/auth0/angular2-jwt.svg?branch=master)](https://travis-ci.org/auth0/angular2-jwt)
+[![npm version](https://img.shields.io/npm/v/angular2-jwt.svg)](https://www.npmjs.com/package/angular2-jwt) [![license](https://img.shields.io/npm/l/angular2-jwt.svg)](https://www.npmjs.com/package/angular2-jwt)
 
 **angular2-jwt** is a helper library for working with [JWTs](http://jwt.io/introduction) in your Angular 2 applications.
 


### PR DESCRIPTION
This adds .travis.yml file to the repo, so that we are able to spot errors right away through CI.
It is configured to use node v4. I think that's a sane default.

It also adds a badge in the README. :rocket: :tada: 