### PR TITLE
README: new link for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **angular2-jwt** is a helper library for working with [JWTs](http://jwt.io/introduction) in your Angular 2 applications.
 
-For examples on integrating **angular2-jwt** with Webpack and SystemJS, see [auth0-angular2](https://github.com/auth0/auth0-angular2).
+For examples on integrating **angular2-jwt** with SystemJS, see [auth0-angular2](https://github.com/auth0-samples/auth0-angularjs2-systemjs-sample).
 
 ## What is This Library For?
 


### PR DESCRIPTION
There are no Webpack examples yet...

Link to repo:
https://github.com/auth0-samples/auth0-angularjs2-webpack-sample
... But it's empty...