### PR TITLE
define 'buffer' as a dependency because js-base64 needs 'buffer' when…

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "rxjs": "5.0.0-beta.12"
   },
   "dependencies": {
+    "buffer": "^5.0.0",
     "js-base64": "^2.1.9"
   }
 }


### PR DESCRIPTION
Consider  defining  'buffer' as a dependency because js-base64 needs 'buffer' when it does not have the node.js internal [Buffer](https://nodejs.org/api/buffer.html)  available when running inside the browser

See:
https://github.com/dankogai/js-base64/blob/master/base64.js#L20


If you don't like this PR,  I  suggest adding it in  the README, or some other solution without dependencies. 

