### PR TITLE
Remove js-base64 dependency

### DIFF
--- a/angular2-jwt.spec.ts
+++ b/angular2-jwt.spec.ts
@@ -1,7 +1,6 @@
 import "core-js";
 import {AuthConfig, AuthHttp, tokenNotExpired, JwtHelper} from "./angular2-jwt";
 import {Observable} from "rxjs";
-import {Base64} from "js-base64";
 
 const expiredToken="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjB9.m2OKoK5-Fnbbg4inMrsAQKsehq2wpQYim8695uLdogk";
 const validToken="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjk5OTk5OTk5OTl9.K_lUwtGbvjCHP8Ff-gW9GykydkkXzHKRPbACxItvrFU";
@@ -58,7 +57,7 @@ describe('JwtHelper', ()=> {
     describe('urlBase64Decode',()=>{
         it('should successfully decode payloads with funny symbols (A Euro symbol in this case) simplified',()=>{
             const expected="€";
-            const payload=Base64.encode(expected);
+            const payload="4oKs"
             const actual:any=jwtHelper.urlBase64Decode(payload);
             expect(actual).toBe(expected);
         });

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -1,4 +1,3 @@
-import { Base64 } from 'js-base64';
 import { Injectable, Provider } from '@angular/core';
 import { Http, Headers, Request, RequestOptions, RequestOptionsArgs, RequestMethod, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
@@ -188,8 +187,14 @@ export class JwtHelper {
         throw 'Illegal base64url string!';
       }
     }
-    // This does not use btoa because it does not support unicode and the various fixes were... wonky.
-    return Base64.decode(output);
+    return this.b64DecodeUnicode(output);
+  }
+
+  // https://developer.mozilla.org/en/docs/Web/API/WindowBase64/Base64_encoding_and_decoding#The_Unicode_Problem
+  private b64DecodeUnicode(str) {
+    return decodeURIComponent(Array.prototype.map.call(atob(str), (c) => {
+      return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
   }
 
   public decodeToken(token: string): any {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,5 @@
     "rxjs": "5.0.0-beta.12"
   },
   "dependencies": {
-    "js-base64": "^2.1.9"
   }
 }


### PR DESCRIPTION
Was added to handle unicode payloads and avoiding using the deprecated
escape method.
Replace the full base64 encoder/decoder, with a workaround using atob
and decodeURIComponent.

Different solution for #174 
Should also avoid #199 and #192
And also don't really need #200 
