### PR TITLE
fix(deploy): npm package does not work with AOT compile

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,16 @@ npm-debug.log
 # OS generated files
 Thumbs.db
 .DS_Store
+
+# TypeScript source files, apart generated type definitions
+*.ts
+!*.d.ts
+
+# Other generated files
+*.spec.*
+*.map
+
+# Other build-related files
+.travis.yml
+karma.*
+tsconfig.*


### PR DESCRIPTION
It still includes .ts source files, which are picked up instead of compiled .js files and make the build fail. As pointed in several references (see one below), original TS source files should not be published with package.

This PR should fix #198 

References: 

* https://medium.com/@OCombe/how-to-publish-a-library-for-angular-2-on-npm-5f48cdabf435#.itgejz5cy
