### PR TITLE
Fixing withCredentials to be reused from Http

### DIFF
--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -114,6 +114,7 @@ export class AuthHttp {
         });
       }
     } else {
+      req.withCredentials = this.http._defaultOptions.withCredentials;
       req.headers.set(this.config.headerName, this.config.headerPrefix + token);
     }
 


### PR DESCRIPTION
Even the Http having withCredentials = true configured, the requests with AuthHttp were not reusing