### PR TITLE
custom config tokenName in default tokenGetter

### DIFF
--- a/angular2-jwt.spec.ts
+++ b/angular2-jwt.spec.ts
@@ -45,6 +45,16 @@ describe('AuthConfig', ()=> {
         expect(config.tokenGetter).toBeDefined();
         expect(config.tokenGetter()).toBe("this is a token");
     });
+    
+    it('should use custom token name in default tokenGetter', ()=> {
+      const configExpected = { tokenName: 'Token' };
+      const token = 'token';
+      const config = new AuthConfig(configExpected).getConfig();
+      localStorage.setItem(configExpected.tokenName, token);
+      expect(config).toBeDefined();
+      expect(config.tokenName).toBe(configExpected.tokenName);
+      expect(config.tokenGetter()).toBe(token);
+    });
 
 });
 

--- a/angular2-jwt.ts
+++ b/angular2-jwt.ts
@@ -58,6 +58,10 @@ export class AuthConfig {
     } else {
       this._config.headerPrefix = AuthConfigConsts.HEADER_PREFIX_BEARER;
     }
+    
+    if (config.tokenName && !config.tokenGetter) {
+      this._config.tokenGetter = () => localStorage.getItem(config.tokenName) as string;
+    }
   }
 
   public getConfig():IAuthConfig {


### PR DESCRIPTION
Fixed: use custom config tokenName in default tokenGetter method #207