### PR TITLE
fix(#218) don't ignore map files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -11,7 +11,6 @@ Thumbs.db
 
 # Other generated files
 *.spec.*
-*.map
 
 # Other build-related files
 .travis.yml


### PR DESCRIPTION
I spent some time looking at the angular 2 modules as an example of what we should be doing, and they did include the .map files.

I tried to figure out how they used the "module" keyword and compiling to es2015, but I couldn't find any docs. At some point I'll drop into the angular gitter and pester someone to see how to do it.