### PR TITLE
Author link to Auth0.com invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ If you have found a bug or if you have a feature request, please report them at 
 
 ## Author
 
-[Auth0](auth0.com)
+[Auth0](https://auth0.com)
 
 ## License
 


### PR DESCRIPTION
Was going to https://github.com/auth0/angular2-jwt/blob/master/auth0.com