### PR TITLE
Set version RxJS version constraint to match 5.0.0 releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "karma-webpack": "^1.7.0",
     "phantomjs-prebuilt": "^2.1.7",
     "reflect-metadata": "0.1.8",
-    "rxjs": "5.0.0-beta.12",
+    "rxjs": "~5.0.0-beta.12",
     "typescript": "^2.0.2",
     "webpack": "^1.13.0",
     "zone.js": "~0.6.12"


### PR DESCRIPTION
This constraint matches versions >= 5.0.0-beta.12 && < 5.1.0
Fixes #233