### PR TITLE
support angular 2.3.x & 2.4.x with release version of rxjs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Thumbs.db
 !custom.d.ts
 .idea/
 *.iml
+*.metadata.json
+*.ngsummary.json
+*.ngfactory.ts

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "tsc --watch",
     "test": "karma start",
-    "prepublish": "tsc"
+    "prepublish": "tsc",
+    "ngc":"ngc"
   },
   "keywords": [
     "angular",
@@ -24,12 +25,15 @@
   },
   "main": "angular2-jwt.js",
   "typings": "./angular2-jwt.d.ts",
+  "types": "./angular2-jwt.d.ts",
   "homepage": "https://github.com/auth0/angular2-jwt#readme",
   "devDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/core": "^2.0.0",
-    "@angular/http": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
+    "@angular/common": "^2.4.2",
+    "@angular/compiler": "^2.4.2",
+    "@angular/compiler-cli": "^2.4.2",
+    "@angular/core": "^2.4.2",
+    "@angular/http": "^2.4.2",
+    "@angular/platform-browser": "^2.4.2",
     "@types/jasmine": "^2.2.33",
     "@types/js-base64": "^2.1.3",
     "awesome-typescript-loader": "^2.2.4",
@@ -45,13 +49,13 @@
     "phantomjs-prebuilt": "^2.1.7",
     "reflect-metadata": "0.1.8",
     "rxjs": "~5.0.0-beta.12",
-    "typescript": "^2.0.2",
+    "typescript": ">=2.0.2 <=2.0.10",
     "webpack": "^1.13.0",
-    "zone.js": "~0.6.12"
+    "zone.js": "~0.7.2"
   },
   "peerDependencies": {
     "@angular/core": "^2.0.0",
     "@angular/http": "^2.0.0",
-    "rxjs": "5.0.0-beta.12"
+    "rxjs": "^5.0.0"
   }
 }


### PR DESCRIPTION
Should resolve #261, #256, #247. #264 Might also cover #257, #158 

Added ngc, seems to compile okay, without any warnings or errors. I don't have an AOT project to test against yet.

I will rearrange the lib in a followup pull, for now I just want things fixed. I'm going to make it more like https://github.com/manekinekko/angular-library-starter