### PR TITLE
Fix webpack sourcemap warnings by inlining the ts sources

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "sourceMap": true,
+        "inlineSources": true,
         "declaration": true,
         "lib": [
             "dom",


### PR DESCRIPTION
Closes #260 

The warning for webpack users is caused by references to `.ts` source files in the sourcemaps, which aren't distributed in the npm release.

Using the `inlineSources` option will bundle the sources into the sourcemap instead of referencing them, which fixes the problem. This is the way they're doing it in angular and ngrx repos.