### PR TITLE
Fix AuthHttp to get the token only on subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@angular/core": "^2.4.2",
     "@angular/http": "^2.4.2",
     "@angular/platform-browser": "^2.4.2",
-    "@types/jasmine": "^2.2.33",
+    "@types/jasmine": "2.5.41",
     "@types/js-base64": "^2.1.3",
     "awesome-typescript-loader": "^2.2.4",
     "core-js": "^2.3.0",


### PR DESCRIPTION
Http is a cold observable, AuthHttp should replicate it's behavior and so the token should be requested for each new subscription

Fixes #301

The version freeze for @types/jasmine was due to new syntax used available only in Typescript >= 2.1.0