### PR TITLE
Added mimetype for ts files

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,6 +43,10 @@ module.exports = function (config) {
             //"IE",
             "PhantomJS"
         ],
+        
+        mime: {
+            'text/x-typescript': ['ts']
+        },
 
         // Continuous Integration mode
         // if true, it capture browsers, run tests and exit


### PR DESCRIPTION
Fixed `Refused to execute script from 'http://localhost:9876/base/angular2-jwt.spec.ts' because its MIME type ('video/mp2t') is not executable.`

Chrome launcher can be used in tests again.