### PR TITLE
Emit es2015 as well as .metadata.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules
 npm-debug.log
 typings
+es2015
+*.tgz
 
 Thumbs.db
 .DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,8 @@ Thumbs.db
 .travis.yml
 karma.*
 tsconfig.*
+*.tgz
+
+# Idea files
+.idea/
+*.iml

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "scripts": {
     "dev": "tsc --watch",
     "test": "karma start",
-    "prepublish": "tsc",
-    "ngc":"ngc"
+    "prepublish": "npm run es2015 && npm run ngc",
+    "ngc": "ngc -p ./tsconfig.aot.json",
+    "es2015": "tsc -p ./tsconfig.es2015.json"
   },
   "keywords": [
     "angular",
@@ -24,8 +25,11 @@
     "url": "https://github.com/auth0/angular2-jwt/issues"
   },
   "main": "angular2-jwt.js",
+  "module": "./es2015/angular2-jwt.js",
+  "es2015": "./es2015/angular2-jwt.js",
   "typings": "./angular2-jwt.d.ts",
   "types": "./angular2-jwt.d.ts",
+  "readmeFilename": "README.md",
   "homepage": "https://github.com/auth0/angular2-jwt#readme",
   "devDependencies": {
     "@angular/common": "^2.4.2||^4.0.0",

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -1,8 +1,7 @@
 {
     "extends": "./tsconfig.json",
     "compilerOptions": {
-        "declaration": true,
-        "emitDecoratorMetadata": false
+        "declaration": true
     },
     "angularCompilerOptions": {
         "annotateForClosureCompiler": true,

--- a/tsconfig.aot.json
+++ b/tsconfig.aot.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "declaration": true,
+        "emitDecoratorMetadata": false
+    },
+    "angularCompilerOptions": {
+        "annotateForClosureCompiler": true,
+        "strictMetadataEmit": true,
+        "skipTemplateCodegen": true
+    }
+}

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "module": "es2015",
+        "outDir": "es2015/",
+        "emitDecoratorMetadata": false
+    }
+}

--- a/tsconfig.es2015.json
+++ b/tsconfig.es2015.json
@@ -2,7 +2,6 @@
     "extends": "./tsconfig.json",
     "compilerOptions": {
         "module": "es2015",
-        "outDir": "es2015/",
-        "emitDecoratorMetadata": false
+        "outDir": "es2015/"
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,21 @@
 {
     "compilerOptions": {
-        "noImplicitAny": true,
+        "target": "es5",
         "module": "commonjs",
-        "target": "ES5",
-        "emitDecoratorMetadata": true,
-        "experimentalDecorators": true,
+        "moduleResolution": "node",
         "sourceMap": true,
         "inlineSources": true,
-        "declaration": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
         "lib": [
-            "dom",
-            "es2015.collection",
-            "es2015.promise",
-            "es5",
-            "es2015.iterable"
+            "es6",
+            "dom"
         ],
-        "moduleResolution":"node"
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "alwaysStrict": true
     },
     "files": [
         "angular2-jwt.ts",


### PR DESCRIPTION
…to allow better use with AOT and Rollup.

Es2015 modules are required for Rollup/Webpack 2 to allow tree-shaking. 

metadata.json files are used by AoT compiler (ngc).

As a reference I used [@angular/material](https://github.com/angular/material2) to have best compatibility with all tools.