### PR TITLE
Fix(#380): Introduced offset seconds configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ class App {
 * Header Prefix: `Bearer`
 * Token Name: `token`
 * Token Getter Function: `(() => localStorage.getItem(tokenName))`
+* Offset Seconds Getter Function: `(() => 50)`
 * Supress error and continue with regular HTTP request if no JWT is saved: `false`
 * Global Headers: none
 
-If you wish to configure the `headerName`, `headerPrefix`, `tokenName`, `tokenGetter` function, `noTokenScheme`, `globalHeaders`, or `noJwtError` boolean, you can using `provideAuth` or the factory pattern (see below).
+If you wish to configure the `headerName`, `headerPrefix`, `tokenName`, `tokenGetter`, `offsetGetter` functions, `noTokenScheme`, `globalHeaders`, or `noJwtError` boolean, you can using `provideAuth` or the factory pattern (see below).
 
 #### Errors
 

--- a/angular2-jwt.spec.ts
+++ b/angular2-jwt.spec.ts
@@ -31,6 +31,7 @@ describe('AuthConfig', ()=> {
         expect(config.noTokenScheme).toBe(false);
         expect(config.globalHeaders).toEqual([]);
         expect(config.tokenGetter).toBeDefined();
+        expect(config.offsetGetter).toBeDefined();
         const token = "Token";
         localStorage.setItem(config.tokenName, token);
         expect(config.tokenGetter()).toBe(token);
@@ -42,6 +43,7 @@ describe('AuthConfig', ()=> {
             headerPrefix: "Bar",
             tokenName: "token",
             tokenGetter: ()=>"this is a token",
+            offsetGetter: () => 0,
             noJwtError: true,
             globalHeaders: [{"header": "value"}, {"header2": "value2"}],
             noTokenScheme: true
@@ -56,6 +58,8 @@ describe('AuthConfig', ()=> {
         expect(config.globalHeaders).toEqual(configExpected.globalHeaders);
         expect(config.tokenGetter).toBeDefined();
         expect(config.tokenGetter()).toBe("this is a token");
+        expect(config.offsetGetter).toBeDefined();
+        expect(config.offsetGetter()).toBe(0);
     });
     
     it('should use custom token name in default tokenGetter', ()=> {


### PR DESCRIPTION
If the clock on the client machine is not synced and JWT is short lived, HTTP requests fail with error:
_No JWT present or has expired_

This has been fixed by introducing a new configuration `offsetGetter` in `IAuthConfig`  to set the offset seconds.

It fixes issue #380 