### PR TITLE
config parameter should be optional

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ export * from './src/jwtoptions.token';
 
 export interface JwtModuleOptions {
   jwtOptionsProvider?: Provider,
-  config: {
+  config?: {
     tokenGetter?: () => string | Promise<string>;
     headerName?: string;
     authScheme?: string;


### PR DESCRIPTION
This PR makes the config parameter optional because you can provide jwtOptionsProvider or the config object