### PR TITLE
v1.0 beta: Keep previous headers if set before being intercepted

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -72,7 +72,7 @@ export class JwtInterceptor implements HttpInterceptor {
 
     if (token && tokenIsExpired && this.skipWhenExpired) {
       request = request.clone();
-    } else if (token && this.isWhitelistedDomain(request)) {
+    } else if (token && this.isWhitelistedDomain(request) && !request.headers.has(this.headerName)) {
       request = request.clone({
         setHeaders: {
           [this.headerName]: `${this.authScheme}${token}`


### PR DESCRIPTION
This should fix the simplest case of #417 .

---

Keep the headers if they were set before being intercepted instead of always overwriting them.

This would allow sending a custom `refresh_token` using the same header as the default for `access_token` ( `Authorization: Bearer <refresh_token>` ).

Right now, it would always overwrite the header with the token retrieved by the `tokenGetter`, instead of keeping the custom header when it was already set.