### PR TITLE
Added support for tokenGetter functions returning an Observable

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 import { NgModule, ModuleWithProviders, Optional, SkipSelf, Provider } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 import { JwtInterceptor } from './src/jwt.interceptor';
 import { JwtHelperService } from './src/jwthelper.service';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
@@ -11,7 +12,7 @@ export * from './src/jwtoptions.token';
 export interface JwtModuleOptions {
   jwtOptionsProvider?: Provider,
   config?: {
-    tokenGetter?: () => string | Promise<string>;
+    tokenGetter?: () => string | Promise<string> | Observable<string>;
     headerName?: string;
     authScheme?: string;
     whitelistedDomains?: Array<string | RegExp>;

--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -13,7 +13,7 @@ import 'rxjs/add/operator/mergeMap';
 
 @Injectable()
 export class JwtInterceptor implements HttpInterceptor {
-  tokenGetter: () => string | Promise<string>;
+  tokenGetter: () => string | Promise<string> | Observable<string>;
   headerName: string;
   authScheme: string;
   whitelistedDomains: Array<string | RegExp>;
@@ -90,6 +90,10 @@ export class JwtInterceptor implements HttpInterceptor {
 
     if (token instanceof Promise) {
       return Observable.fromPromise(token).mergeMap((asyncToken: string) => {
+        return this.handleInterception(asyncToken, request, next);
+      });
+    } else if (token instanceof Observable) {
+      return token.mergeMap((asyncToken: string) => {
         return this.handleInterception(asyncToken, request, next);
       });
     } else {

--- a/src/jwthelper.service.ts
+++ b/src/jwthelper.service.ts
@@ -1,14 +1,7 @@
-import { Injectable, Inject } from '@angular/core';
-import { JWT_OPTIONS } from './jwtoptions.token';
+import { Injectable } from '@angular/core';
 
 @Injectable()
 export class JwtHelperService {
-  tokenGetter: () => string;
-
-  constructor(@Inject(JWT_OPTIONS) config:any) {
-    this.tokenGetter = config.tokenGetter;
-  }
-
   public urlBase64Decode(str: string): string {
     let output = str.replace(/-/g, '+').replace(/_/g, '/');
     switch (output.length % 4) {
@@ -76,7 +69,7 @@ export class JwtHelperService {
     );
   }
 
-  public decodeToken(token: string = this.tokenGetter()): any {
+  public decodeToken(token: string): any {
     let parts = token.split('.');
 
     if (parts.length !== 3) {
@@ -91,7 +84,7 @@ export class JwtHelperService {
     return JSON.parse(decoded);
   }
 
-  public getTokenExpirationDate(token: string = this.tokenGetter()): Date {
+  public getTokenExpirationDate(token: string): Date {
     let decoded: any;
     decoded = this.decodeToken(token);
 
@@ -105,7 +98,7 @@ export class JwtHelperService {
     return date;
   }
 
-  public isTokenExpired(token: string = this.tokenGetter(), offsetSeconds?: number): boolean {
+  public isTokenExpired(token: string, offsetSeconds?: number): boolean {
     let date = this.getTokenExpirationDate(token);
     offsetSeconds = offsetSeconds || 0;
 


### PR DESCRIPTION
Also removed default parameter calls of the injected `tokenGetter` function in `JwtHelperService`, because it won't work in the case of async `tokenGetter`s.

And as the helper methods in `JwtHelperService` are never called without the token parameter, there is currently no need to inject any `tokenGetter`s into `JwtHelperService`, so the `JWT_OPTIONS` injection was removed as well.