### PR TITLE
Do not default to true on error during domain whitelist verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This library does not have any functionality for (or opinion about) implementing
 
 > **Note:** This library can only be used with Angular 4.3 and higher because it relies on an `HttpInterceptor` from Angular's `HttpClient`. This feature is not available on lower versions.
 
+> **Note:** Internet Explorer 11 support requires a [URL polyfill](https://github.com/github/url-polyfill)
+
 ## Installation
 
 ```bash

--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -36,23 +36,16 @@ export class JwtInterceptor implements HttpInterceptor {
   }
 
   isWhitelistedDomain(request: HttpRequest<any>): boolean {
-    let requestUrl: URL;
-    try {
-      requestUrl = new URL(request.url);
-      return (
-        this.whitelistedDomains.findIndex(
-          domain =>
-            typeof domain === 'string'
-              ? domain === requestUrl.host
-              : domain instanceof RegExp ? domain.test(requestUrl.host) : false
-        ) > -1
-      );
-    } catch (err) {
-      // if we're here, the request is made
-      // to the same domain as the Angular app
-      // so it's safe to proceed
-      return true;
-    }
+    const requestUrl = new URL(request.url);
+
+    return (
+      this.whitelistedDomains.findIndex(
+        domain =>
+          typeof domain === 'string'
+            ? domain === requestUrl.host
+            : domain instanceof RegExp ? domain.test(requestUrl.host) : false
+      ) > -1
+    );
   }
 
   handleInterception(


### PR DESCRIPTION
This prevents false-positive whitelist checks in IE11. (fixes #437).