### PR TITLE
#471 Extend Angular dependency version to include Angular 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,12 @@
   "types": "./angular2-jwt.d.ts",
   "homepage": "https://github.com/auth0/angular2-jwt#readme",
   "devDependencies": {
-    "@angular/common": "^2.4.2||^4.0.0",
-    "@angular/compiler": "^2.4.2||^4.0.0",
-    "@angular/compiler-cli": "^2.4.2||^4.0.0",
-    "@angular/core": "^2.4.2||^4.0.0",
-    "@angular/http": "^2.4.2||^4.0.0",
-    "@angular/platform-browser": "^2.4.2||^4.0.0",
+    "@angular/common": "^2.4.2||^5.0.0",
+    "@angular/compiler": "^2.4.2||^5.0.0",
+    "@angular/compiler-cli": "^2.4.2||^5.0.0",
+    "@angular/core": "^2.4.2||^5.0.0",
+    "@angular/http": "^2.4.2||^5.0.0",
+    "@angular/platform-browser": "^2.4.2||^5.0.0",
     "@types/jasmine": "^2.5.46",
     "@types/js-base64": "^2.1.3",
     "awesome-typescript-loader": "^3.1.2",
@@ -54,8 +54,8 @@
     "zone.js": "~0.7.2||~0.8.5"
   },
   "peerDependencies": {
-    "@angular/core": "^2.0.0||^4.0.0",
-    "@angular/http": "^2.0.0||^4.0.0",
+    "@angular/core": "^2.0.0||^5.0.0",
+    "@angular/http": "^2.0.0||^5.0.0",
     "rxjs": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular2-jwt",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Helper library for handling JWTs in Angular 2+",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Re issue #471: Prevent NPM warnings about version mismatch when used with Angular 5.x.