### PR TITLE
Support for aot compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Be sure to import the `HttpClientModule` as well.
 import { JwtModule } from '@auth0/angular-jwt';
 import { HttpClientModule } from '@angular/common/http';
 
+export function tokenGetter() {
+  return localStorage.getItem('access_token');
+}
+
 @NgModule({
   bootstrap: [AppComponent],
   imports: [
@@ -35,9 +39,7 @@ import { HttpClientModule } from '@angular/common/http';
     HttpClientModule,
     JwtModule.forRoot({
       config: {
-        tokenGetter: () => {
-          return localStorage.getItem('access_token');
-        },
+        tokenGetter: tokenGetter,
         whitelistedDomains: ['localhost:3001']
       }
     })


### PR DESCRIPTION
Fix the following error when trying to build using AoT compilation:
```
ERROR in Error during template compile of 'AppModule'
[1]   Function expressions are not supported in decorators in 'ɵ0'
[1]     'ɵ0' contains the error at client/app/app.module.ts(38,22)
[1]       Consider changing the function expression into an exported function.
```

More info: https://github.com/angular/angular/issues/10789

Merge also this one: https://github.com/auth0/angular2-jwt/pull/486