### PR TITLE
Resolved  Cannot read property 'split' of null error, isTokenExpired should return TRUE if token is null

### DIFF
--- a/src/jwthelper.service.ts
+++ b/src/jwthelper.service.ts
@@ -77,6 +77,10 @@ export class JwtHelperService {
   }
 
   public decodeToken(token: string = this.tokenGetter()): any {
+    if(token===null) {
+      throw new Error('The token doesn\'t appear to exist.');
+    }
+
     let parts = token.split('.');
 
     if (parts.length !== 3) {

--- a/src/jwthelper.service.ts
+++ b/src/jwthelper.service.ts
@@ -114,7 +114,7 @@ export class JwtHelperService {
     offsetSeconds = offsetSeconds || 0;
 
     if (date === null) {
-      return false;
+      return true;
     }
 
     return !(date.valueOf() > new Date().valueOf() + offsetSeconds * 1000);

--- a/src/jwthelper.service.ts
+++ b/src/jwthelper.service.ts
@@ -78,7 +78,7 @@ export class JwtHelperService {
 
   public decodeToken(token: string = this.tokenGetter()): any {
     if(token===null) {
-      throw new Error('The token doesn\'t appear to exist.');
+      return null;
     }
 
     let parts = token.split('.');


### PR DESCRIPTION
This check removes the following error :
`ERROR Error: Uncaught (in promise): TypeError: Cannot read property 'split' of null
TypeError: Cannot read property 'split' of null
    at JwtHelperService.decodeToken (jwthelper.service.js:62)`