### PR TITLE
add domain in case of there is no one in the request url

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -38,7 +38,7 @@ export class JwtInterceptor implements HttpInterceptor {
   }
 
   isWhitelistedDomain(request: HttpRequest<any>): boolean {
-    const requestUrl = new URL(request.url);
+    const requestUrl = new URL(request.url,'http://127.0.0.1:8080');
 
     return (
       this.whitelistedDomains.findIndex(


### PR DESCRIPTION
in case of  no request domain is configured, like '/path/resources/1235'. the URL creation fail.
Define a default domain, allow to avoid the error  .

default domain would be considered only when the passed url doesn't have one.