### PR TITLE
Fix typo, needed comma in forRoot import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ export function tokenGetter() {
     JwtModule.forRoot({
       config: {
         tokenGetter: tokenGetter,
-        whitelistedDomains: ['localhost:3001']
+        whitelistedDomains: ['localhost:3001'],
         blacklistedRoutes: ['localhost:3001/auth/']
       }
     })


### PR DESCRIPTION
Fix typo, needed comma in forRoot import example