### PR TITLE
Fix whitelist for urls without host

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -42,7 +42,7 @@ export class JwtInterceptor implements HttpInterceptor {
     const requestUrl = URL.parse(request.url, false, true);
 
     return (
-      this.whitelistedDomains.findIndex(
+      requestUrl.host === null || this.whitelistedDomains.findIndex(
         domain =>
           typeof domain === 'string'
             ? domain === requestUrl.host


### PR DESCRIPTION
Accept URLs with implicit domain name (like '/api/users') by default, as specified in the documentation (https://github.com/auth0/angular2-jwt#blacklistedroutes-array)

Fixes #504