### PR TITLE
issue #518 : urls without host are whitelisted by default

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -41,7 +41,7 @@ export class JwtInterceptor implements HttpInterceptor {
   isWhitelistedDomain(request: HttpRequest<any>): boolean {
     const requestUrl = URL.parse(request.url, false, true);
 
-    return (
+    return (requestUrl.host===null)||(
       this.whitelistedDomains.findIndex(
         domain =>
           typeof domain === 'string'


### PR DESCRIPTION
The isWhitelistedDomain methode should return true when request has no host.