### PR TITLE
fix: mixed import styles breaking app bundling using rollup

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -10,7 +10,7 @@ import { JWT_OPTIONS } from './jwtoptions.token';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/operator/mergeMap';
-const URL = require('url');
+import { parse } from 'url';
 
 @Injectable()
 export class JwtInterceptor implements HttpInterceptor {
@@ -39,7 +39,7 @@ export class JwtInterceptor implements HttpInterceptor {
   }
 
   isWhitelistedDomain(request: HttpRequest<any>): boolean {
-    const requestUrl = URL.parse(request.url, false, true);
+    const requestUrl = parse(request.url, false, true);
 
     return (
       this.whitelistedDomains.findIndex(


### PR DESCRIPTION
When bundling an angular application using rollup and running it, a `ReferenceError` is thrown, stating that `require is not defined`.

The reason is `jwt.interceptor.js` mixing `require` and `import` statements, which leads to rollup ignoring it. This results in the require statement making it into the resulting js bundle, causing the above error.

The issue is reported here: https://github.com/rollup/rollup-plugin-commonjs/issues/273