### PR TITLE
Enable whitelistedDomains and blacklistedRoutes to be tested by functions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,8 +14,8 @@ export interface JwtModuleOptions {
     tokenGetter?: () => string | Promise<string>;
     headerName?: string;
     authScheme?: string;
-    whitelistedDomains?: Array<string | RegExp>;
-    blacklistedRoutes?: Array<string | RegExp>;
+    whitelistedDomains?: Array<string | RegExp | (() => string | RegExp)>;
+    blacklistedRoutes?: Array<string | RegExp | (() => string | RegExp)>;
     throwNoTokenError?: boolean;
     skipWhenExpired?: boolean;
   }


### PR DESCRIPTION
When using aot compiler option you are not allowed to call a function (https://angular.io/guide/aot-compiler#no-arrow-functions) in the definition of `whitelistedDomains` or `blacklistedRoutes`. I have a function in the environment that specifies the domain of my API server, eg. `environment.getApiDomain()`.

These changes allows me to delay the definition of `whitelistedDomains` and `blacklistedRoutes`.

