### PR TITLE
fix(isTokenExpired): Update isTokenExpired for optional exp claim

### DIFF
--- a/src/jwthelper.service.ts
+++ b/src/jwthelper.service.ts
@@ -119,7 +119,7 @@ export class JwtHelperService {
     offsetSeconds = offsetSeconds || 0;
 
     if (date === null) {
-      return true;
+      return false;
     }
 
     return !(date.valueOf() > new Date().valueOf() + offsetSeconds * 1000);


### PR DESCRIPTION
An update to address issues [#557](https://github.com/auth0/angular2-jwt/issues/557) and [#558](https://github.com/auth0/angular2-jwt/issues/558).

Currently, `isTokenExpired` returns `true` if `exp` is not present. According to the [JWT spec](https://tools.ietf.org/html/rfc7519#section-4.1.4) this is optional.