### PR TITLE
Avoid confusion regarding whitelist of https

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ export function tokenGetter() {
     JwtModule.forRoot({
       config: {
         tokenGetter: tokenGetter,
-        whitelistedDomains: ['localhost:3001'],
-        blacklistedRoutes: ['localhost:3001/auth/']
+        whitelistedDomains: ['example.com'],
+        blacklistedRoutes: ['example.com/examplebadroute/']
       }
     })
   ]
@@ -105,7 +105,7 @@ JwtModule.forRoot({
 
 Authenticated requests should only be sent to domains you know and trust. Many applications make requests to APIs from multiple domains, some of which are not controlled by the developer. Since there is no way to know what the API being called will do with the information contained in the request, it is best to not send the user's token any and all APIs in a blind fashion.
 
-List any domains you wish to allow authenticated requests to be sent to by specifying them in the the `whitelistedDomains` array.
+List any domains you wish to allow authenticated requests to be sent to by specifying them in the the `whitelistedDomains` array. **Note that standard http port 80 and https port 443 requests don't require a port to be specified. A port is only required in the whitelisted host name if you are authenticating against a non-standard port e.g. localhost:3001**
 
 ```ts
 // ...


### PR DESCRIPTION
The current example implies that port is required in the whitelist, this results in issues being created from people wondering why their whitelist doesn't work. This clarifies when a port is required in the whitelist.