### PR TITLE
Skip tokenGetter for non-whitelisted or blacklisted requests

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -104,8 +104,11 @@ export class JwtInterceptor implements HttpInterceptor {
     request: HttpRequest<any>,
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
+    if (!this.isWhitelistedDomain(request) || this.isBlacklistedRoute(request)) {
+      return next.handle(request);
+    }
+    
     const token = this.tokenGetter();
-
     if (token instanceof Promise) {
       return from(token).pipe(mergeMap(
         (asyncToken: string | null) => {


### PR DESCRIPTION
This should fix **circular reference** and **Maximum call stack size exceeded** errors when the tokenGetter contains a http request, by skipping tokenGetter for non-whitelisted or blacklisted requests.