### PR TITLE
fix: remove rxjs internal imports

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -7,8 +7,7 @@ import {
 } from '@angular/common/http';
 import { JwtHelperService } from './jwthelper.service';
 import { JWT_OPTIONS } from './jwtoptions.token';
-import { Observable } from "rxjs/internal/Observable";
-import { from } from "rxjs/internal/observable/from";
+import { Observable, from } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { parse } from 'url';
 


### PR DESCRIPTION
### Changes

When trying this lib with ivy I get:
```
WARNING in Entry point '@auth0/angular-jwt' contains deep imports into 'rxjs/internal/observable/from'. This is probably not a problem, but may cause the compilation of entry points to be out of order.
```

This change removes the rxjs internal imports.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](../CONTRIBUTING.md), if applicable
