### PR TITLE
Refactor deep rxjs imports and use named define

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -7,8 +7,7 @@ import {
 } from '@angular/common/http';
 import { JwtHelperService } from './jwthelper.service';
 import { JWT_OPTIONS } from './jwtoptions.token';
-import { Observable } from "rxjs/internal/Observable";
-import { from } from "rxjs/internal/observable/from";
+import { from, Observable } from "rxjs";
 import { mergeMap } from 'rxjs/operators';
 import { parse } from 'url';
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,9 +9,6 @@ const helpers = require('./config/helpers'),
 /**
  * Webpack Plugins
  */
-const ProvidePlugin = require('webpack/lib/ProvidePlugin');
-const DefinePlugin = require('webpack/lib/DefinePlugin');
-const LoaderOptionsPlugin = require('webpack/lib/LoaderOptionsPlugin');
 
 module.exports = {
   devtool: 'inline-source-map',
@@ -26,13 +23,14 @@ module.exports = {
     path: helpers.root('bundles'),
     publicPath: '/',
     filename: 'core.umd.js',
-    library: 'angular-jwt',
+    library: '@auth0/angular-jwt',
     libraryTarget: 'umd',
-    globalObject: 'typeof self !== \'undefined\' ? self : this'
+    umdNamedDefine: true,
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
 
   // require those dependencies but don't bundle them
-  externals: [/^\@angular\//, /^rxjs\//],
+  externals: [/^\@angular\//, /^rxjs\/?/],
 
   module: {
     rules: [


### PR DESCRIPTION
### Changes

This PR makes `@auth0/angular-jwt` usable with Bazel. The fix consists
of two parts:

1. Update of deep rxjs imports. They don't work with Bazel but also
increase the final bundle size unnecessary.
2. Use named define for the library.

### References

https://github.com/angular/angular-bazel-example/pull/463

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](../CONTRIBUTING.md), if applicable
