### PR TITLE
Revert "Merge pull request #604 from driverpt/patch-1"

### DIFF
--- a/src/jwt.interceptor.ts
+++ b/src/jwt.interceptor.ts
@@ -39,15 +39,15 @@ export class JwtInterceptor implements HttpInterceptor {
 
   isWhitelistedDomain(request: HttpRequest<any>): boolean {
     const requestUrl: any = parse(request.url, false, true);
-    const requestHost: string = requestUrl.host || (typeof location === 'object' && location.host)
+
     return (
-      requestHost === undefined ||
+      requestUrl.host === null ||
       this.whitelistedDomains.findIndex(
         domain =>
           typeof domain === 'string'
-            ? domain === requestHost
+            ? domain === requestUrl.host
             : domain instanceof RegExp
-              ? domain.test(requestHost)
+              ? domain.test(requestUrl.host)
               : false
       ) > -1
     );


### PR DESCRIPTION
Reverting this merge as it introduces an undesirable change to the
default whitelisting behaviour.

@driverpt We've discovered that this commit introduces a change to the default behaviour of the library. It basically requires everything to be whitelisted, regardless of whether you're making a request to the same domain with a host or not.

The documentation states:

> Note: If requests are sent to the same domain that is serving your Angular application, you do not need to add that domain to the whitelistedDomains array. However, this is only the case if you don't specify the domain in the Http request.

This line of code says "if the request URL has no host, then use the host from the location object"

The following code then goes on to check that the host is in the whitelist array, finds that it's not there, so returns false.

Could you please supply a patch which causes the default behaviour to continue working? In the meantime I will revert these commits.

This reverts commit 33e441f8e1b7dd6d4067f6a4401b420d0b75b604, reversing
changes made to 5f8db7f1f35c2f01467e286dba28c0f2c42a26b6.

