### PR TITLE
Pass HttpRequest to the tokenGetter

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ export class AppComponent {
 
 ## Configuration Options
 
-### `tokenGetter: function`
+### `tokenGetter: function(?HttpRequest)`
 
 The `tokenGetter` is a function which returns the user's token. This function simply needs to make a retrieval call to wherever the token is stored. In many cases, the token will be stored in local storage or session storage.
 
@@ -98,6 +98,24 @@ JwtModule.forRoot({
   config: {
     // ...
     tokenGetter: () => {
+      return localStorage.getItem("access_token");
+    },
+  },
+});
+```
+
+If you have multiple tokens for multiple domains, you can use the `HttpRequest` passed to the `tokenGetter` function to get the correct token for each intercepted request.
+
+```ts
+// ...
+JwtModule.forRoot({
+  config: {
+    // ...
+    tokenGetter: (request) => {
+      if (request.url.includes("foo")) {
+        return localStorage.getItem("access_token_foo");
+      }
+
       return localStorage.getItem("access_token");
     },
   },

--- a/projects/angular-jwt/src/lib/angular-jwt.module.ts
+++ b/projects/angular-jwt/src/lib/angular-jwt.module.ts
@@ -1,14 +1,21 @@
-import { NgModule, ModuleWithProviders, Optional, SkipSelf, Provider } from '@angular/core';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
-import {JwtInterceptor} from './jwt.interceptor';
-import {JWT_OPTIONS} from './jwtoptions.token';
-import {JwtHelperService} from './jwthelper.service';
-
+import {
+  NgModule,
+  ModuleWithProviders,
+  Optional,
+  SkipSelf,
+  Provider,
+} from "@angular/core";
+import { HttpRequest, HTTP_INTERCEPTORS } from "@angular/common/http";
+import { JwtInterceptor } from "./jwt.interceptor";
+import { JWT_OPTIONS } from "./jwtoptions.token";
+import { JwtHelperService } from "./jwthelper.service";
 
 export interface JwtModuleOptions {
   jwtOptionsProvider?: Provider;
   config?: {
-    tokenGetter?: () => string | null | Promise<string | null>;
+    tokenGetter?: (
+      request?: HttpRequest<any>
+    ) => string | null | Promise<string | null>;
     headerName?: string;
     authScheme?: string;
     whitelistedDomains?: Array<string | RegExp>;
@@ -20,10 +27,11 @@ export interface JwtModuleOptions {
 
 @NgModule()
 export class JwtModule {
-
   constructor(@Optional() @SkipSelf() parentModule: JwtModule) {
     if (parentModule) {
-      throw new Error('JwtModule is already loaded. It should only be imported in your application\'s main module.');
+      throw new Error(
+        "JwtModule is already loaded. It should only be imported in your application's main module."
+      );
     }
   }
   static forRoot(options: JwtModuleOptions): ModuleWithProviders<JwtModule> {
@@ -33,15 +41,14 @@ export class JwtModule {
         {
           provide: HTTP_INTERCEPTORS,
           useClass: JwtInterceptor,
-          multi: true
+          multi: true,
         },
-        options.jwtOptionsProvider ||
-        {
+        options.jwtOptionsProvider || {
           provide: JWT_OPTIONS,
-          useValue: options.config
+          useValue: options.config,
         },
-        JwtHelperService
-      ]
+        JwtHelperService,
+      ],
     };
   }
 }

--- a/projects/angular-jwt/src/lib/jwt.interceptor.ts
+++ b/projects/angular-jwt/src/lib/jwt.interceptor.ts
@@ -14,7 +14,9 @@ import { from, Observable } from "rxjs";
 
 @Injectable()
 export class JwtInterceptor implements HttpInterceptor {
-  tokenGetter: () => string | null | Promise<string | null>;
+  tokenGetter: (
+    request?: HttpRequest<any>
+  ) => string | null | Promise<string | null>;
   headerName: string;
   authScheme: string;
   whitelistedDomains: Array<string | RegExp>;
@@ -112,7 +114,7 @@ export class JwtInterceptor implements HttpInterceptor {
     ) {
       return next.handle(request);
     }
-    const token = this.tokenGetter();
+    const token = this.tokenGetter(request);
 
     if (token instanceof Promise) {
       return from(token).pipe(


### PR DESCRIPTION
### Changes

-  The intercepted `HttpRequest` is passed to the `tokenGetter` function so you can fetch different tokens based on the request.

### References
- Resolves #648
- Resolves #641

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](../CONTRIBUTING.md), if applicable
