### PR TITLE
feat: add domain on runtime

### DIFF
--- a/projects/angular-jwt/src/lib/jwthelper.service.ts
+++ b/projects/angular-jwt/src/lib/jwthelper.service.ts
@@ -6,9 +6,20 @@ import { JWT_OPTIONS } from './jwtoptions.token';
 @Injectable()
 export class JwtHelperService {
   tokenGetter: () => string;
+  private config: any;
 
   constructor(@Inject(JWT_OPTIONS) config = null) {
+    this.config = config;
     this.tokenGetter = config && config.tokenGetter || function() {};
+  }
+
+  public addWhitelistDomain(domain: string): void {
+    if (!this.config.whitelistedDomains) {
+      this.config.whitelistedDomains = [];
+    }
+
+    const domains = [...this.config.whitelistedDomains, domain];
+    this.config.whitelistedDomains = [...new Set(domains)];
   }
 
   public urlBase64Decode(str: string): string {

--- a/src/app/services/example-http.service.spec.ts
+++ b/src/app/services/example-http.service.spec.ts
@@ -4,7 +4,7 @@ import {
   HttpClientTestingModule,
   HttpTestingController,
 } from "@angular/common/http/testing";
-import { JwtModule } from "angular-jwt";
+import { JwtHelperService, JwtModule } from 'angular-jwt';
 
 export function tokenGetter() {
   return "TEST_TOKEN";
@@ -25,6 +25,7 @@ export function tokenGetterWithRequest(request) {
 describe("Example HttpService: with simple tokken getter", () => {
   let service: ExampleHttpService;
   let httpMock: HttpTestingController;
+  let jwtMock: JwtHelperService;
 
   const validRoutes = [
     `/assets/example-resource.json`,
@@ -62,6 +63,7 @@ describe("Example HttpService: with simple tokken getter", () => {
     });
     service = TestBed.get(ExampleHttpService);
     httpMock = TestBed.get(HttpTestingController);
+    jwtMock = TestBed.get(JwtHelperService);
   });
 
   it("should add Authorisation header", () => {
@@ -93,6 +95,22 @@ describe("Example HttpService: with simple tokken getter", () => {
       expect(httpRequest.request.headers.has("Authorization")).toEqual(false);
     })
   );
+
+  it(`should add dynamically a whitelisted domain `, () => {
+    const url = 'http://add-whitelisted-domain.com';
+    jwtMock.addWhitelistDomain('add-whitelisted-domain.com');
+    service.testRequest(url).subscribe((response) => {
+      expect(response).toBeTruthy();
+    });
+
+    const httpRequest = httpMock.expectOne(url);
+
+    expect(httpRequest.request.headers.has("Authorization")).toEqual(true);
+    expect(httpRequest.request.headers.get("Authorization")).toEqual(
+      `Bearer ${tokenGetter()}`
+    );
+  });
+
 });
 
 describe("Example HttpService: with request based tokken getter", () => {


### PR DESCRIPTION
### Changes

This PR will add the possibility to add a domain to the whitelist on runtime. 

There are situations that the domain is not settled before running the applications (e.g. getting an url from a remote API). In order to add the url to the service, we need to add the domain somehow to the config. By exposing a method `addWhitelistDomain` we have the possibility to add a new custom whitelisted domain.

### References

See also https://github.com/auth0/angular2-jwt/issues/647

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](../CONTRIBUTING.md), if applicable
