### PR TITLE
Support whitelisting of domains with non default (80m 443) ports

### DIFF
--- a/projects/angular-jwt/src/lib/jwt.interceptor.ts
+++ b/projects/angular-jwt/src/lib/jwt.interceptor.ts
@@ -23,6 +23,7 @@ export class JwtInterceptor implements HttpInterceptor {
   blacklistedRoutes: Array<string | RegExp>;
   throwNoTokenError: boolean;
   skipWhenExpired: boolean;
+  standardPorts: string[] = ["80", "443"];
 
   constructor(
     @Inject(JWT_OPTIONS) config: any,
@@ -42,14 +43,22 @@ export class JwtInterceptor implements HttpInterceptor {
 
   isWhitelistedDomain(request: HttpRequest<any>): boolean {
     const requestUrl: any = parse(request.url, false, true);
+    const hostName =
+      requestUrl.hostname !== null
+        ? `${requestUrl.hostname}${
+            requestUrl.port && !this.standardPorts.includes(requestUrl.port)
+              ? ":" + requestUrl.port
+              : ""
+          }`
+        : requestUrl.hostname;
 
     return (
-      requestUrl.hostname === null ||
+      hostName === null ||
       this.whitelistedDomains.findIndex((domain) =>
         typeof domain === "string"
-          ? domain === requestUrl.hostname
+          ? domain === hostName
           : domain instanceof RegExp
-          ? domain.test(requestUrl.hostname)
+          ? domain.test(hostName)
           : false
       ) > -1
     );

--- a/src/app/services/example-http.service.spec.ts
+++ b/src/app/services/example-http.service.spec.ts
@@ -33,6 +33,7 @@ describe("Example HttpService: with simple tokken getter", () => {
     `http://whitelisted.com:443/api/test`,
     `http://whitelisted-regex.com/api/`,
     `https://whitelisted-regex.com/api/`,
+    `http://localhost:3000`,
   ];
   const invalidRoutes = [
     `http://whitelisted.com/api/blacklisted`,
@@ -41,6 +42,7 @@ describe("Example HttpService: with simple tokken getter", () => {
     `http://whitelisted.com/api/blacklisted-regex`,
     `http://whitelisted-regex.com/api/blacklisted-regex`,
     `http://foo.com/bar`,
+    "http://localhost:4000",
   ];
 
   beforeEach(() => {
@@ -50,7 +52,11 @@ describe("Example HttpService: with simple tokken getter", () => {
         JwtModule.forRoot({
           config: {
             tokenGetter: tokenGetter,
-            whitelistedDomains: ["whitelisted.com", /whitelisted-regex*/],
+            whitelistedDomains: [
+              "whitelisted.com",
+              /whitelisted-regex*/,
+              "localhost:3000",
+            ],
             blacklistedRoutes: [
               "http://whitelisted.com/api/blacklisted-protocol",
               "//whitelisted.com/api/blacklisted",


### PR DESCRIPTION
### Changes

- Support domains with a port other than the default HTTP ports (HTTP: 80, HTTPS: 443)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](../CONTRIBUTING.md), if applicable
