### PR TITLE
feat: extracted JwtConfig from JwtModuleOptions

### DIFF
--- a/projects/angular-jwt/src/lib/angular-jwt.module.ts
+++ b/projects/angular-jwt/src/lib/angular-jwt.module.ts
@@ -10,19 +10,21 @@ import { JwtInterceptor } from "./jwt.interceptor";
 import { JWT_OPTIONS } from "./jwtoptions.token";
 import { JwtHelperService } from "./jwthelper.service";
 
+export interface JwtConfig {
+  tokenGetter?: (
+    request?: HttpRequest<any>
+  ) => string | null | Promise<string | null>;
+  headerName?: string;
+  authScheme?: string;
+  whitelistedDomains?: Array<string | RegExp>;
+  blacklistedRoutes?: Array<string | RegExp>;
+  throwNoTokenError?: boolean;
+  skipWhenExpired?: boolean;
+};
+
 export interface JwtModuleOptions {
   jwtOptionsProvider?: Provider;
-  config?: {
-    tokenGetter?: (
-      request?: HttpRequest<any>
-    ) => string | null | Promise<string | null>;
-    headerName?: string;
-    authScheme?: string;
-    whitelistedDomains?: Array<string | RegExp>;
-    blacklistedRoutes?: Array<string | RegExp>;
-    throwNoTokenError?: boolean;
-    skipWhenExpired?: boolean;
-  };
+  config?: JwtConfig;
 }
 
 @NgModule()


### PR DESCRIPTION
Extracted and exported `JwtConfig` to be used with Providers such as this:

```ts
export const jwtOptionsFactory = (authStoreFacade: AuthStoreFacade): JwtConfig => ({
	tokenGetter: () => authStoreFacade.accessToken$.pipe(take(1)).toPromise(),
	whitelistedDomains: [environment.domain],
});
```

This way we get IntelliSense in this scenario too, with minimal effort.

Issue: https://github.com/auth0/angular2-jwt/issues/660
