### PR TITLE
Add IE11 warning to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm install @auth0/angular-jwt
 yarn add @auth0/angular-jwt
 ```
 
+**This library relies on the URL interface which is not supported in IE11.**
+To solve the IE11 compatibility, you can add a polyfill.
+
+- run `npm i --save url-polyfill`
+- add `import 'url-polyfill';` to `polyfills.ts` in your project
+
 ## Usage: Standalone
 
 If you are only interested in the JWT Decoder, and are not interested in extended


### PR DESCRIPTION
### Changes
- Added a warning on IE11 compatibility and a solution to the readme.

### References
- #509
- #674

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md), if applicable
