### PR TITLE
feat: add type hinting for the JwtHelperService.decodeToken method

### DIFF
--- a/projects/angular-jwt/src/lib/jwthelper.service.ts
+++ b/projects/angular-jwt/src/lib/jwthelper.service.ts
@@ -77,7 +77,7 @@ export class JwtHelperService {
     );
   }
 
-  public decodeToken(token: string = this.tokenGetter()): any {
+  public decodeToken<T = any>(token: string = this.tokenGetter()): T {
     if (!token || token === "") {
       return null;
     }


### PR DESCRIPTION
### Changes

Updated the `decodeToken` method in the class `JwtHelperService` to accept a generic type argument that will be used as the type of the returned value, defaulting to `any` to preserve the current behavior when no type argument is used and avoid a breaking change.

With the change the user can hint the type of the value returned by the `decodeToken` method instead of having to resort to a type assertion.

#### Example of usage without a type hint:
![Screenshot_25](https://user-images.githubusercontent.com/5291103/93718926-abb85e00-fb55-11ea-9be8-d24dcb46fea1.png)

#### Example of usage with a type hint:
![Screenshot_26](https://user-images.githubusercontent.com/5291103/93718934-bbd03d80-fb55-11ea-8090-2a22f36e771b.png)

### References

Issue: #678 

### Checklist

- [✔] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [✔] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [✔] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) have been run/followed
- [✔] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md), if applicable
