### PR TITLE
Allow origin domain to be disallowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ JwtModule.forRoot({
 });
 ```
 
+### `alwaysAllowOriginDomain: boolean`
+
+By default, the origin domain (the domain of your Angular application) is always allowed, even when not explicitly included in `allowedDomains`.  If you want to to disable this, set `alwaysAllowOriginDomain` to false.
+
+```ts
+// ...
+JwtModule.forRoot({
+  config: {
+    // ...
+    alwaysAllowOriginDomain: false,
+  },
+});
+```
+
 ### `disallowedRoutes: array`
 
 If you do not want to replace the authorization headers for specific routes, list them here. This can be useful if your

--- a/projects/angular-jwt/src/lib/jwt.interceptor.ts
+++ b/projects/angular-jwt/src/lib/jwt.interceptor.ts
@@ -20,6 +20,7 @@ export class JwtInterceptor implements HttpInterceptor {
   headerName: string;
   authScheme: string | ((request?: HttpRequest<any>) => string);
   allowedDomains: Array<string | RegExp>;
+  alwaysAllowOriginDomain: boolean;
   disallowedRoutes: Array<string | RegExp>;
   throwNoTokenError: boolean;
   skipWhenExpired: boolean;
@@ -37,6 +38,7 @@ export class JwtInterceptor implements HttpInterceptor {
         ? config.authScheme
         : "Bearer ";
     this.allowedDomains = config.allowedDomains || [];
+    this.alwaysAllowOriginDomain = config.alwaysAllowOriginDomain || true;
     this.disallowedRoutes = config.disallowedRoutes || [];
     this.throwNoTokenError = config.throwNoTokenError || false;
     this.skipWhenExpired = config.skipWhenExpired;
@@ -47,7 +49,7 @@ export class JwtInterceptor implements HttpInterceptor {
 
     // If the host equals the current window origin,
     // the domain is allowed by default
-    if (requestUrl.host === this.document.location.host) {
+    if (this.alwaysAllowOriginDomain && (requestUrl.host === this.document.location.host)) {
       return true;
     }
 


### PR DESCRIPTION
### Changes

I added an option to not automatically allow the origin domain.  Currently, https://github.com/auth0/angular2-jwt/blob/0a1608d17f83b179af80b71be88f4c06bc7d2107/projects/angular-jwt/src/lib/jwt.interceptor.ts#L48-L52 always allows the origin domain.  The comment in the code says that this behavior is default; however, there was no way to override that default.

By adding the `alwaysAllowOriginDomain` option in the configuration, this default can be overridden so that the origin domain is only allowed if explicitly included in `allowedDomains`.  If the user does not add this option, the current behavior is unchanged.

### References

- [Added README.md section](https://github.com/njlaw/angular2-jwt/blob/disallow-origin-host/README.md#alwaysalloworigindomain-boolean)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md), if applicable
