### PR TITLE
Update readme to mention support for Angular versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 [![npm version](https://badge.fury.io/js/%40auth0%2Fangular-jwt.svg)](https://badge.fury.io/js/%40auth0%2Fangular-jwt)
 
-**@auth0/angular-jwt v5.1.x is to be used with Angular v12+. For Angular v10 and v11, please use @auth0/angular-jwt v5.0.x. For any other Angular version (down untill v6) use @auth0/angular-jwt v4**
-
 This library provides an `HttpInterceptor` which automatically attaches a [JSON Web Token](https://jwt.io) to `HttpClient` requests.
 
 This library does not have any functionality for (or opinion about) implementing user authentication and retrieving JWTs to begin with. Those details will vary depending on your setup, but in most cases, you will use a regular HTTP request to authenticate your users and then save their JWTs in local storage or in a cookie if successful.
+
+## Supported Angular versions
+This project only supports the [actively supported versions of Angular as stated in the Angular documentation](https://angular.io/guide/releases#actively-supported-versions). Whilst other versions might be compatible they are not actively supported
 
 ## Sponsor
 

--- a/README.md
+++ b/README.md
@@ -2,23 +2,17 @@
 
 [![npm version](https://badge.fury.io/js/%40auth0%2Fangular-jwt.svg)](https://badge.fury.io/js/%40auth0%2Fangular-jwt)
 
-### **NOTE:** This library is now at version 5 and is published on npm as `@auth0/angular-jwt`. If you're looking for the pre-v1.0 version of this library, it can be found in the `pre-v1.0` branch and on npm as `angular2-jwt`.
-
-**Version v5 of this library has some breaking changes concerning the `allowedDomains` and `disallowedRoutes`.**
-
-**@auth0/angular-jwt v5 is to be used with Angular v10+ and RxJS v6+. For Angular v6+ to v9, use @auth0/angular-jwt v4**
+**@auth0/angular-jwt v5.1.x is to be used with Angular v12+. For Angular v10 and v11, please use @auth0/angular-jwt v5.0.x. For any other Angular version (down untill v6) use @auth0/angular-jwt v4**
 
 This library provides an `HttpInterceptor` which automatically attaches a [JSON Web Token](https://jwt.io) to `HttpClient` requests.
 
 This library does not have any functionality for (or opinion about) implementing user authentication and retrieving JWTs to begin with. Those details will vary depending on your setup, but in most cases, you will use a regular HTTP request to authenticate your users and then save their JWTs in local storage or in a cookie if successful.
 
-> **Note:** This library can only be used with Angular 4.3 and higher because it relies on an `HttpInterceptor` from Angular's `HttpClient`. This feature is not available on lower versions.
-
 ## Sponsor
 
 |||
 |-|-|
-|![auth0 logo](https://user-images.githubusercontent.com/83319/31722733-de95bbde-b3ea-11e7-96bf-4f4e8f915588.png)|If you want to quickly add secure token-based authentication to your Angular projects, feel free to check Auth0's Angular SDK and free plan at [auth0.com/developers](https://auth0.com/developers?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=angular2-jwt&utm_content=auth)|
+|![auth0 logo](https://user-images.githubusercontent.com/83319/31722733-de95bbde-b3ea-11e7-96bf-4f4e8f915588.png)|If you want to quickly add secure token-based authentication to your Angular projects, feel free to check [Auth0's Angular SDK](https://github.com/auth0/auth0-angular) and free plan at [auth0.com/developers](https://auth0.com/developers?utm_source=GHsponsor&utm_medium=GHsponsor&utm_campaign=angular2-jwt&utm_content=auth)|
 
 ## Installation
 


### PR DESCRIPTION
### Changes

With #735 , we will no longer have support for Angular < 12. As Angular no longer supports Angular < 12 themselves, this should be fine.

As the readme is very outdated, this PR updates it to better reflect todays support based on the supported versions by Angular.

It also removes the explicit mention about breaking changes in v5, as v5 has been around for over two years now.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md), if applicable
