### PR TITLE
Support promise based tokenGetter in JwtHelperService

### DIFF
--- a/projects/angular-jwt/src/lib/jwt.interceptor.ts
+++ b/projects/angular-jwt/src/lib/jwt.interceptor.ts
@@ -1,16 +1,16 @@
-import { Injectable, Inject } from "@angular/core";
+import { Injectable, Inject } from '@angular/core';
 import {
   HttpRequest,
   HttpHandler,
   HttpEvent,
   HttpInterceptor,
-} from "@angular/common/http";
-import { DOCUMENT } from "@angular/common";
-import { JwtHelperService } from "./jwthelper.service";
-import { JWT_OPTIONS } from "./jwtoptions.token";
+} from '@angular/common/http';
+import { DOCUMENT } from '@angular/common';
+import { JwtHelperService } from './jwthelper.service';
+import { JWT_OPTIONS } from './jwtoptions.token';
 
-import { map, mergeMap } from "rxjs/operators";
-import { defer, from, Observable, of } from "rxjs";
+import { map, mergeMap } from 'rxjs/operators';
+import { defer, from, Observable, of } from 'rxjs';
 
 const fromPromiseOrValue = <T>(input: T | Promise<T>) => {
   if (input instanceof Promise) {
@@ -29,7 +29,7 @@ export class JwtInterceptor implements HttpInterceptor {
   disallowedRoutes: Array<string | RegExp>;
   throwNoTokenError: boolean;
   skipWhenExpired: boolean;
-  standardPorts: string[] = ["80", "443"];
+  standardPorts: string[] = ['80', '443'];
 
   constructor(
     @Inject(JWT_OPTIONS) config: any,
@@ -37,11 +37,11 @@ export class JwtInterceptor implements HttpInterceptor {
     @Inject(DOCUMENT) private document: Document
   ) {
     this.tokenGetter = config.tokenGetter;
-    this.headerName = config.headerName || "Authorization";
+    this.headerName = config.headerName || 'Authorization';
     this.authScheme =
-      config.authScheme || config.authScheme === ""
+      config.authScheme || config.authScheme === ''
         ? config.authScheme
-        : "Bearer ";
+        : 'Bearer ';
     this.allowedDomains = config.allowedDomains || [];
     this.disallowedRoutes = config.disallowedRoutes || [];
     this.throwNoTokenError = config.throwNoTokenError || false;
@@ -60,13 +60,13 @@ export class JwtInterceptor implements HttpInterceptor {
     // If not the current domain, check the allowed list
     const hostName = `${requestUrl.hostname}${
       requestUrl.port && !this.standardPorts.includes(requestUrl.port)
-        ? ":" + requestUrl.port
-        : ""
+        ? ':' + requestUrl.port
+        : ''
     }`;
 
     return (
       this.allowedDomains.findIndex((domain) =>
-        typeof domain === "string"
+        typeof domain === 'string'
           ? domain === hostName
           : domain instanceof RegExp
           ? domain.test(hostName)
@@ -83,7 +83,7 @@ export class JwtInterceptor implements HttpInterceptor {
 
     return (
       this.disallowedRoutes.findIndex((route: string | RegExp) => {
-        if (typeof route === "string") {
+        if (typeof route === 'string') {
           const parsedRoute: URL = new URL(
             route,
             this.document.location.origin
@@ -111,7 +111,7 @@ export class JwtInterceptor implements HttpInterceptor {
     const authScheme = this.jwtHelper.getAuthScheme(this.authScheme, request);
 
     if (!token && this.throwNoTokenError) {
-      throw new Error("Could not get token from tokenGetter function.");
+      throw new Error('Could not get token from tokenGetter function.');
     }
 
     if (token) {

--- a/projects/angular-jwt/src/lib/jwt.interceptor.ts
+++ b/projects/angular-jwt/src/lib/jwt.interceptor.ts
@@ -125,7 +125,7 @@ export class JwtInterceptor implements HttpInterceptor {
                 },
               })
         ),
-        mergeMap((request) => next.handle(request))
+        mergeMap((innerRequest) => next.handle(innerRequest))
       );
     }
 

--- a/projects/angular-jwt/src/lib/jwt.interceptor.ts
+++ b/projects/angular-jwt/src/lib/jwt.interceptor.ts
@@ -1,17 +1,23 @@
-import { Injectable, Inject } from '@angular/core';
+import { Injectable, Inject } from "@angular/core";
 import {
   HttpRequest,
   HttpHandler,
   HttpEvent,
   HttpInterceptor,
-} from '@angular/common/http';
-import { DOCUMENT } from '@angular/common';
-import { JwtHelperService } from './jwthelper.service';
-import { JWT_OPTIONS } from './jwtoptions.token';
+} from "@angular/common/http";
+import { DOCUMENT } from "@angular/common";
+import { JwtHelperService } from "./jwthelper.service";
+import { JWT_OPTIONS } from "./jwtoptions.token";
 
-import { mergeMap } from 'rxjs/operators';
-import { from, Observable } from 'rxjs';
+import { map, mergeMap } from "rxjs/operators";
+import { defer, from, Observable, of } from "rxjs";
 
+const fromPromiseOrValue = <T>(input: T | Promise<T>) => {
+  if (input instanceof Promise) {
+    return defer(() => input);
+  }
+  return of(input);
+};
 @Injectable()
 export class JwtInterceptor implements HttpInterceptor {
   tokenGetter: (
@@ -23,7 +29,7 @@ export class JwtInterceptor implements HttpInterceptor {
   disallowedRoutes: Array<string | RegExp>;
   throwNoTokenError: boolean;
   skipWhenExpired: boolean;
-  standardPorts: string[] = ['80', '443'];
+  standardPorts: string[] = ["80", "443"];
 
   constructor(
     @Inject(JWT_OPTIONS) config: any,
@@ -31,11 +37,11 @@ export class JwtInterceptor implements HttpInterceptor {
     @Inject(DOCUMENT) private document: Document
   ) {
     this.tokenGetter = config.tokenGetter;
-    this.headerName = config.headerName || 'Authorization';
+    this.headerName = config.headerName || "Authorization";
     this.authScheme =
-      config.authScheme || config.authScheme === ''
+      config.authScheme || config.authScheme === ""
         ? config.authScheme
-        : 'Bearer ';
+        : "Bearer ";
     this.allowedDomains = config.allowedDomains || [];
     this.disallowedRoutes = config.disallowedRoutes || [];
     this.throwNoTokenError = config.throwNoTokenError || false;
@@ -54,13 +60,13 @@ export class JwtInterceptor implements HttpInterceptor {
     // If not the current domain, check the allowed list
     const hostName = `${requestUrl.hostname}${
       requestUrl.port && !this.standardPorts.includes(requestUrl.port)
-        ? ':' + requestUrl.port
-        : ''
+        ? ":" + requestUrl.port
+        : ""
     }`;
 
     return (
       this.allowedDomains.findIndex((domain) =>
-        typeof domain === 'string'
+        typeof domain === "string"
           ? domain === hostName
           : domain instanceof RegExp
           ? domain.test(hostName)
@@ -77,7 +83,7 @@ export class JwtInterceptor implements HttpInterceptor {
 
     return (
       this.disallowedRoutes.findIndex((route: string | RegExp) => {
-        if (typeof route === 'string') {
+        if (typeof route === "string") {
           const parsedRoute: URL = new URL(
             route,
             this.document.location.origin
@@ -103,25 +109,26 @@ export class JwtInterceptor implements HttpInterceptor {
     next: HttpHandler
   ) {
     const authScheme = this.jwtHelper.getAuthScheme(this.authScheme, request);
-    let tokenIsExpired = false;
 
     if (!token && this.throwNoTokenError) {
-      throw new Error('Could not get token from tokenGetter function.');
+      throw new Error("Could not get token from tokenGetter function.");
     }
 
-    if (this.skipWhenExpired) {
-      tokenIsExpired = token ? this.jwtHelper.isTokenExpired(token) : true;
+    if (token) {
+      return fromPromiseOrValue(this.jwtHelper._isTokenExpired(token)).pipe(
+        map((isExpired) =>
+          isExpired && this.skipWhenExpired
+            ? request.clone()
+            : request.clone({
+                setHeaders: {
+                  [this.headerName]: `${authScheme}${token}`,
+                },
+              })
+        ),
+        mergeMap((request) => next.handle(request))
+      );
     }
 
-    if (token && tokenIsExpired && this.skipWhenExpired) {
-      request = request.clone();
-    } else if (token) {
-      request = request.clone({
-        setHeaders: {
-          [this.headerName]: `${authScheme}${token}`,
-        },
-      });
-    }
     return next.handle(request);
   }
 
@@ -134,14 +141,10 @@ export class JwtInterceptor implements HttpInterceptor {
     }
     const token = this.tokenGetter(request);
 
-    if (token instanceof Promise) {
-      return from(token).pipe(
-        mergeMap((asyncToken: string | null) => {
-          return this.handleInterception(asyncToken, request, next);
-        })
-      );
-    } else {
-      return this.handleInterception(token, request, next);
-    }
+    return fromPromiseOrValue(token).pipe(
+      mergeMap((asyncToken: string | null) => {
+        return this.handleInterception(asyncToken, request, next);
+      })
+    );
   }
 }

--- a/projects/angular-jwt/src/lib/jwt.interceptor.ts
+++ b/projects/angular-jwt/src/lib/jwt.interceptor.ts
@@ -114,8 +114,14 @@ export class JwtInterceptor implements HttpInterceptor {
       throw new Error('Could not get token from tokenGetter function.');
     }
 
+    let tokenIsExpired = of(false);
+
+    if (this.skipWhenExpired) {
+      tokenIsExpired = token ? fromPromiseOrValue(this.jwtHelper.isTokenExpired(token)) : of(true);
+    }
+
     if (token) {
-      return fromPromiseOrValue(this.jwtHelper._isTokenExpired(token)).pipe(
+      return tokenIsExpired.pipe(
         map((isExpired) =>
           isExpired && this.skipWhenExpired
             ? request.clone()

--- a/projects/angular-jwt/src/lib/jwthelper.service.spec.ts
+++ b/projects/angular-jwt/src/lib/jwthelper.service.spec.ts
@@ -6,7 +6,7 @@ import { JwtModule, JwtHelperService } from 'angular-jwt';
 
 describe('Example HttpService: with simple based tokken getter', () => {
   let service: JwtHelperService;
-  let tokenGetter = jasmine.createSpy('tokenGetter');
+  const tokenGetter = jasmine.createSpy('tokenGetter');
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,7 +44,7 @@ describe('Example HttpService: with simple based tokken getter', () => {
 
 describe('Example HttpService: with a promise based tokken getter', () => {
   let service: JwtHelperService;
-  let tokenGetter = jasmine.createSpy('tokenGetter');
+  const tokenGetter = jasmine.createSpy('tokenGetter');
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/projects/angular-jwt/src/lib/jwthelper.service.spec.ts
+++ b/projects/angular-jwt/src/lib/jwthelper.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+} from '@angular/common/http/testing';
+import { JwtModule, JwtHelperService } from 'angular-jwt';
+
+describe('Example HttpService: with simple based tokken getter', () => {
+  let service: JwtHelperService;
+  let tokenGetter = jasmine.createSpy('tokenGetter');
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        JwtModule.forRoot({
+          config: {
+            tokenGetter: tokenGetter,
+            allowedDomains: ['example-1.com', 'example-2.com', 'example-3.com'],
+          },
+        }),
+      ],
+    });
+    service = TestBed.inject(JwtHelperService);
+  });
+
+  it('should return null when tokenGetter returns null', () => {
+    tokenGetter.and.returnValue(null);
+
+    expect(service.decodeToken()).toBeNull();
+  });
+
+  it('should throw an error when token contains less than 2 dots', () => {
+    tokenGetter.and.returnValue('a.b');
+
+    expect(() => service.decodeToken()).toThrow();
+  });
+
+  it('should throw an error when token contains more than 2 dots', () => {
+    tokenGetter.and.returnValue('a.b.c.d');
+
+    expect(() => service.decodeToken()).toThrow();
+  });
+});
+
+describe('Example HttpService: with a promise based tokken getter', () => {
+  let service: JwtHelperService;
+  let tokenGetter = jasmine.createSpy('tokenGetter');
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+        JwtModule.forRoot({
+          config: {
+            tokenGetter: tokenGetter,
+            allowedDomains: ['example-1.com', 'example-2.com', 'example-3.com'],
+          },
+        }),
+      ],
+    });
+    service = TestBed.inject(JwtHelperService);
+  });
+
+  it('should return null when tokenGetter returns null', async () => {
+    tokenGetter.and.resolveTo(null);
+
+    await expectAsync(service.decodeToken()).toBeResolvedTo(null);
+  });
+
+  it('should throw an error when token contains less than 2 dots', async () => {
+    tokenGetter.and.resolveTo('a.b');
+
+    await expectAsync(service.decodeToken()).toBeRejected();
+  });
+
+  it('should throw an error when token contains more than 2 dots', async () => {
+    tokenGetter.and.resolveTo('a.b.c.d');
+
+    await expectAsync(service.decodeToken()).toBeRejected();
+  });
+
+  it('should return the token when tokenGetter returns a valid JWT', async () => {
+    tokenGetter.and.resolveTo('eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2NjY2ODU4NjAsImV4cCI6MTY5ODIyMTg2MCwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.lXrRPRZ8VNUpwBsT9fLPPO0p0BotQle4siItqg4LqLQ');
+
+    await expectAsync(service.decodeToken()).toBeResolvedTo(jasmine.anything());
+  });
+});
+

--- a/projects/angular-jwt/src/lib/jwthelper.service.ts
+++ b/projects/angular-jwt/src/lib/jwthelper.service.ts
@@ -6,7 +6,7 @@ import { JWT_OPTIONS } from './jwtoptions.token';
 
 @Injectable()
 export class JwtHelperService {
-  tokenGetter: () => string;
+  tokenGetter: () => string | Promise<string>;
 
   constructor(@Inject(JWT_OPTIONS) config = null) {
     this.tokenGetter = (config && config.tokenGetter) || function () {};
@@ -77,7 +77,17 @@ export class JwtHelperService {
     );
   }
 
-  public decodeToken<T = any>(token: string = this.tokenGetter()): T {
+  public decodeToken<T = any>(token: string = null): T | Promise<T> {
+    let _token = token || this.tokenGetter();
+
+    if (_token instanceof Promise) {
+      return _token.then(t => this._decodeToken(t));
+    }
+
+    return this._decodeToken(_token);
+  }
+
+  private _decodeToken(token: string) {
     if (!token || token === '') {
       return null;
     }
@@ -99,8 +109,19 @@ export class JwtHelperService {
   }
 
   public getTokenExpirationDate(
-    token: string = this.tokenGetter()
-  ): Date | null {
+    token: string = null
+  ): Date | null | Promise<Date> {
+
+    const _token = token || this.tokenGetter();
+
+    if (_token instanceof Promise) {
+      return _token.then(t => this._getTokenExpirationDate(t));
+    }
+
+    return this._getTokenExpirationDate(_token);
+  }
+
+  private _getTokenExpirationDate(token : string) {
     let decoded: any;
     decoded = this.decodeToken(token);
 
@@ -115,7 +136,20 @@ export class JwtHelperService {
   }
 
   public isTokenExpired(
-    token: string = this.tokenGetter(),
+    token: string = null,
+    offsetSeconds?: number
+  ): boolean | Promise<boolean> {
+    const _token = token || this.tokenGetter();
+
+    if (_token instanceof Promise) {
+      return _token.then(t => this._isTokenExpired(t, offsetSeconds));
+    }
+
+    return this._isTokenExpired(_token, offsetSeconds);
+  }
+
+  public _isTokenExpired(
+    token: string,
     offsetSeconds?: number
   ): boolean {
     if (!token || token === '') {

--- a/projects/angular-jwt/src/lib/jwthelper.service.ts
+++ b/projects/angular-jwt/src/lib/jwthelper.service.ts
@@ -78,7 +78,7 @@ export class JwtHelperService {
   }
 
   public decodeToken<T = any>(token: string = null): T | Promise<T> {
-    let _token = token || this.tokenGetter();
+    const _token = token || this.tokenGetter();
 
     if (_token instanceof Promise) {
       return _token.then(t => this._decodeToken(t));
@@ -121,7 +121,7 @@ export class JwtHelperService {
     return this._getTokenExpirationDate(_token);
   }
 
-  private _getTokenExpirationDate(token : string) {
+  private _getTokenExpirationDate(token: string) {
     let decoded: any;
     decoded = this.decodeToken(token);
 

--- a/src/app/services/example-http.service.spec.ts
+++ b/src/app/services/example-http.service.spec.ts
@@ -6,24 +6,28 @@ import {
 } from '@angular/common/http/testing';
 import { JwtModule } from 'angular-jwt';
 
+const TEST_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
+const TEST_TOKEN_1 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbmUgRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.cMErWtEf7DxCXJl8C9q0L7ttkm-Ex54UWHsOCMGbtUc';
+const TEST_TOKEN_2 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikphc29uIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.f2z_alWh9QWCkPHtAdVMRlZOb_2krfZ1wd78Bj2_YEg';
+
 export function tokenGetter() {
-  return 'TEST_TOKEN';
+  return TEST_TOKEN;
 }
 
 export function tokenGetterWithRequest(request) {
   if (request.url.includes('1')) {
-    return 'TEST_TOKEN_1';
+    return TEST_TOKEN_1;
   }
 
   if (request.url.includes('2')) {
-    return 'TEST_TOKEN_2';
+    return TEST_TOKEN_2;
   }
 
-  return 'TEST_TOKEN';
+  return TEST_TOKEN;
 }
 
 export function tokenGetterWithPromise() {
-  return Promise.resolve('TEST_TOKEN');
+  return Promise.resolve(TEST_TOKEN);
 }
 
 describe('Example HttpService: with promise based tokken getter', () => {
@@ -87,7 +91,7 @@ describe('Example HttpService: with promise based tokken getter', () => {
 
       expect(httpRequest.request.headers.has('Authorization')).toEqual(true);
       expect(httpRequest.request.headers.get('Authorization')).toEqual(
-        `Bearer TEST_TOKEN`
+        `Bearer ${TEST_TOKEN}`
       );
     }))
   );

--- a/src/app/services/example-http.service.spec.ts
+++ b/src/app/services/example-http.service.spec.ts
@@ -23,7 +23,7 @@ export function tokenGetterWithRequest(request) {
 }
 
 export function tokenGetterWithPromise() {
-  return Promise.resolve('TEST_TOKEN')
+  return Promise.resolve('TEST_TOKEN');
 }
 
 describe('Example HttpService: with promise based tokken getter', () => {

--- a/src/app/services/example-http.service.spec.ts
+++ b/src/app/services/example-http.service.spec.ts
@@ -6,28 +6,24 @@ import {
 } from '@angular/common/http/testing';
 import { JwtModule } from 'angular-jwt';
 
-const TEST_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c';
-const TEST_TOKEN_1 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbmUgRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.cMErWtEf7DxCXJl8C9q0L7ttkm-Ex54UWHsOCMGbtUc';
-const TEST_TOKEN_2 = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikphc29uIERvZSIsImlhdCI6MTUxNjIzOTAyMn0.f2z_alWh9QWCkPHtAdVMRlZOb_2krfZ1wd78Bj2_YEg';
-
 export function tokenGetter() {
-  return TEST_TOKEN;
+  return 'TEST_TOKEN';
 }
 
 export function tokenGetterWithRequest(request) {
   if (request.url.includes('1')) {
-    return TEST_TOKEN_1;
+    return 'TEST_TOKEN_1';
   }
 
   if (request.url.includes('2')) {
-    return TEST_TOKEN_2;
+    return 'TEST_TOKEN_2';
   }
 
-  return TEST_TOKEN;
+  return 'TEST_TOKEN';
 }
 
 export function tokenGetterWithPromise() {
-  return Promise.resolve(TEST_TOKEN);
+  return Promise.resolve('TEST_TOKEN');
 }
 
 describe('Example HttpService: with promise based tokken getter', () => {
@@ -91,7 +87,7 @@ describe('Example HttpService: with promise based tokken getter', () => {
 
       expect(httpRequest.request.headers.has('Authorization')).toEqual(true);
       expect(httpRequest.request.headers.get('Authorization')).toEqual(
-        `Bearer ${TEST_TOKEN}`
+        `Bearer TEST_TOKEN`
       );
     }))
   );


### PR DESCRIPTION
### Changes

tokenGetter is typed to be able to return a string or a promise. The interceptor can handle when tokenGetter returns a promise, but the JwtHelperService can not.

This PR updates the JwtHelperService in such a way that it can handle Promises.

Note that this does change the public API, but it's not to be considered a breaking change as we actualy fixing incorrect current behavior.

### References

Closes #747 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) have been run/followed
- [x] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md), if applicable
