### PR TITLE
docs: Add Ask DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Release](https://img.shields.io/github/v/release/auth0/angular2-jwt)
 [![codecov](https://codecov.io/gh/auth0/angular2-jwt/branch/main/graph/badge.svg?token=wnauXldcdE)](https://codecov.io/gh/auth0/angular2-jwt)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/angular2-jwt)
 ![Downloads](https://img.shields.io/npm/dw/@auth0/angular-jwt)
 [![License](https://img.shields.io/:license-MIT-blue.svg?style=flat)](https://opensource.org/licenses/MIT)
 [![CircleCI](https://img.shields.io/circleci/build/github/auth0/angular2-jwt)](https://circleci.com/gh/auth0/angular2-jwt)


### PR DESCRIPTION

This pull request adds the 'Ask DeepWiki' badge to the repository's README file.

### Purpose
The badge provides a direct and convenient link for users and contributors to ask questions and get information about this codebase via DeepWiki, improving the repository's overall supportability and accessibility.

### Automation Context
This change was applied via an automated script to ensure consistency across multiple repositories. No other files or functional code have been modified.
