### PR TITLE
Fix CI E401 by repointing lockfile to public npmjs and forcing npm ci to rewrite private-registry hosts via --replace-registry-host=always

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -28,7 +28,11 @@ runs:
 
     - name: Install dependencies
       shell: bash
-      run: npm ci --include=dev
+      # replace-registry-host=always forces npm to resolve every tarball from the
+      # public registry configured above, ignoring any private-registry host that
+      # may have leaked into package-lock.json's "resolved" URLs (which would
+      # otherwise fail with E401). See npm docs: config/replace-registry-host.
+      run: npm ci --include=dev --replace-registry-host=always
 
     - name: Build package
       if: inputs.require-build == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-      - run: npm ci --ignore-scripts
+          registry-url: 'https://registry.npmjs.org'
+      # replace-registry-host=always forces npm to resolve every tarball from the
+      # public registry above, ignoring any private-registry host that may have
+      # leaked into package-lock.json's "resolved" URLs (which would otherwise
+      # fail in public CI with E401). See npm docs: config/replace-registry-host.
+      - run: npm ci --ignore-scripts --replace-registry-host=always
       - run: npm run lint
       - run: npm run build
       - run: npm run test:ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -6623,7 +6623,7 @@
     },
     "node_modules/core-js": {
       "version": "3.48.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/core-js/-/core-js-3.48.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
       "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
       "dev": true,
       "hasInstallScript": true,
@@ -22149,7 +22149,7 @@
     },
     "core-js": {
       "version": "3.48.0",
-      "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/core-js/-/core-js-3.48.0.tgz",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
       "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
       "dev": true
     },


### PR DESCRIPTION
### Changes

CI's `npm ci` was failing with `E401 Incorrect or missing password` because two `core-js@3.48.0` entries in `package-lock.json` had `resolved` URLs pointing at Auth0's private Artifactory (`a0us.jfrog.io`), which is unauthenticated in public CI.

- `package-lock.json`: repointed the two `core-js` `resolved` URLs to the public registry (`registry.npmjs.org`); integrity hashes unchanged (identical tarballs).
- `.github/workflows/build.yml` and `.github/actions/npm-publish/action.yml`: added `--replace-registry-host=always` to `npm ci` (and set `registry-url` in build) so npm rewrites any private-registry host that leaks into the lockfile back to the public registry, preventing recurrence.

`registry-url` alone does not fix this — it only writes an `.npmrc`; npm still fetches from the lockfile's `resolved` host unless `replace-registry-host` rewrites it.

### References

- npm config docs: https://docs.npmjs.com/cli/using-npm/config#replace-registry-host

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All code quality tools/guidelines in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md) have been run/followed
- [ ] All relevant assets have been compiled as directed in the [CONTRIBUTING documentation](https://github.com/auth0/open-source-template/blob/master/CONTRIBUTING.md), if applicable
